### PR TITLE
Hfp stop fixes

### DIFF
--- a/src/components/map/ArriveDepartToggle.js
+++ b/src/components/map/ArriveDepartToggle.js
@@ -1,0 +1,29 @@
+import React from "react";
+import {observer} from "mobx-react";
+
+export default observer(({value, onChange}) => {
+  return (
+    <div>
+      <label>
+        <input
+          type="radio"
+          value="arrive"
+          checked={value === "arrive"}
+          name="showTime"
+          onChange={onChange}
+        />{" "}
+        Arrive
+      </label>
+      <label>
+        <input
+          type="radio"
+          value="depart"
+          checked={value === "depart"}
+          name="showTime"
+          onChange={onChange}
+        />{" "}
+        Depart
+      </label>
+    </div>
+  );
+});

--- a/src/components/map/HfpLayer.js
+++ b/src/components/map/HfpLayer.js
@@ -18,7 +18,7 @@ class HfpLayer extends Component {
     const {selectedJourney, positions} = this.props;
     const journeyId = getJourneyId(selectedJourney);
 
-    // Get only the positions from the same journey and create latNg items for Leaflet.
+    // Get only the positions from the same journey and create latLng items for Leaflet.
     // Additional data can be passed as the third array element which Leaflet won't touch.
     return positions
       .filter((pos) => getJourneyId(pos) === journeyId)

--- a/src/components/map/HfpMarkerLayer.js
+++ b/src/components/map/HfpMarkerLayer.js
@@ -99,7 +99,7 @@ ${position.drst ? `<span class="hfp-marker-drst" />` : ""}
         <Tooltip>
           {moment(position.receivedAt).format("HH:mm:ss")}
           <br />
-          {name}
+          {position.uniqueVehicleId}
           <br />
           Next stop: {position.nextStopId}
           <br />

--- a/src/components/map/Map.css
+++ b/src/components/map/Map.css
@@ -39,3 +39,8 @@
   height: 12px;
   border-radius: 50%;
 }
+
+.timing-stop.early {
+  background: hotpink;
+  border-radius: 50%;
+}

--- a/src/components/map/StopMarker.js
+++ b/src/components/map/StopMarker.js
@@ -7,6 +7,7 @@ import TimingStopIcon from "../../icon-time1.svg";
 import get from "lodash/get";
 import reverse from "lodash/reverse";
 import diffDates from "date-fns/difference_in_seconds";
+import parse from "date-fns/parse";
 
 const stopColor = "#3388ff";
 const selectedStopColor = darken(0.2, stopColor);
@@ -24,25 +25,31 @@ export default ({
 }) => {
   const isTerminal = firstTerminal || lastTerminal;
 
+  let journeyStartedOnTime;
+
+  // Timing stops don't work properly until we have correct timetable info.
+  // TODO: Fix this up when we have.
+
+  if ((firstTerminal || stop.timingStopType) && hfp.length === 1) {
+    const date = time.format("YYYY-MM-DD");
+    const journeyStartHfp = get(reverse(hfp), `[0].journeys[0].depart`, "");
+
+    const startedDate = parse(journeyStartHfp.receivedAt);
+    const journeyStartDate = new Date(`${date}T${journeyStartHfp.journeyStartTime}`);
+
+    // Not "on time" if started 10 or more seconds too early.
+    journeyStartedOnTime = diffDates(journeyStartDate, startedDate) < 10;
+  }
+
   const timingStopIcon = icon({
     iconUrl: TimingStopIcon,
     iconSize: [30, 30],
     iconAnchor: [23, 25 / 2],
     popupAnchor: [3, -15],
-    className: "stop-marker timing-stop",
+    className: `stop-marker timing-stop ${
+      journeyStartedOnTime ? "on-time" : "early"
+    }`,
   });
-
-  let journeyStartedOnTime;
-
-  if (firstTerminal && hfp.length === 1) {
-    const date = time.format("YYYY-MM-DD");
-    const journeyStartHfp = get(reverse(hfp), `[0].journeys[0].depart`, "");
-
-    const startedDate = new Date(journeyStartHfp.receivedAt);
-    const journeyStartDate = new Date(`${date}T${journeyStartHfp.journeyStartTime}`);
-
-    journeyStartedOnTime = Math.abs(diffDates(startedDate, journeyStartDate)) <= 60;
-  }
 
   return React.createElement(
     stop.timingStopType ? Marker : CircleMarker,


### PR DESCRIPTION
Show the vehicle ID when hovering over a HFP marker, make terminal stops be red only when the journey was started too early. Needs JORE timetable info for implementing the same for timing stops.