### PR TITLE
Url state

### DIFF
--- a/src/components/filterbar/StopInput.js
+++ b/src/components/filterbar/StopInput.js
@@ -9,7 +9,7 @@ const getSuggestionValue = (suggestion) =>
     ? `${suggestion.shortId.replace(/ /g, "")} - ${suggestion.nameFi} (${
         suggestion.stopId
       })`
-    : "";
+    : suggestion;
 
 const renderSuggestion = (suggestion) => (
   <span className="suggestion-content">

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -1,9 +1,12 @@
 import React, {Component} from "react";
 import {observer, inject} from "mobx-react";
+import {latLngBounds} from "leaflet";
 import {LeafletMap} from "./LeafletMap";
 import {app} from "mobx-app";
 import invoke from "lodash/invoke";
 import get from "lodash/get";
+import debounce from "lodash/debounce";
+import {setUrlValue, getUrlValue} from "../../stores/UrlManager";
 
 @inject(app("Journey"))
 @observer
@@ -34,13 +37,27 @@ class Map extends Component {
     const map = this.getLeaflet();
 
     if (map) {
-      map.setView(
-        {
-          lat: 60.170988,
-          lng: 24.940842,
-        },
-        this.state.zoom
-      );
+      const urlBounds = getUrlValue("mapBounds");
+
+      if (urlBounds) {
+        const splitUrlBounds = urlBounds.split(",");
+        console.log(urlBounds);
+
+        const bounds = latLngBounds(
+          [splitUrlBounds[1], splitUrlBounds[0]],
+          [splitUrlBounds[3], splitUrlBounds[2]]
+        );
+
+        this.setMapBounds(bounds);
+      } else {
+        map.setView(
+          {
+            lat: 60.170988,
+            lng: 24.940842,
+          },
+          this.state.zoom
+        );
+      }
     }
   }
 
@@ -86,7 +103,11 @@ class Map extends Component {
   onMapChanged = () => {
     const map = this.getLeaflet();
     this.props.onMapChanged(map);
+
+    this.setMapUrlBounds(map.getBounds().toBBoxString());
   };
+
+  setMapUrlBounds = debounce((val) => setUrlValue("mapBounds", val), 500);
 
   onZoom = (event) => {
     const zoom = event.target.getZoom();

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -41,7 +41,6 @@ class Map extends Component {
 
       if (urlBounds) {
         const splitUrlBounds = urlBounds.split(",");
-        console.log(urlBounds);
 
         const bounds = latLngBounds(
           [splitUrlBounds[1], splitUrlBounds[0]],

--- a/src/components/sidepanel/SidepanelList.js
+++ b/src/components/sidepanel/SidepanelList.js
@@ -22,7 +22,7 @@ const ListHeader = styled.header`
   background: transparent;
   font-size: 0.9em;
   border-bottom: 1px solid var(--alt-grey);
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.075);
+  box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.075);
   position: relative;
   z-index: 1;
   line-height: 1.4;

--- a/src/components/sidepanel/StopTimetable.js
+++ b/src/components/sidepanel/StopTimetable.js
@@ -157,7 +157,7 @@ class StopTimetable extends Component {
                         `${firstDepartureTime}:${departure.routeId}:${
                           departure.direction
                         }`,
-                        {}
+                        null
                       );
                     }
 

--- a/src/components/sidepanel/Tabs.js
+++ b/src/components/sidepanel/Tabs.js
@@ -2,6 +2,7 @@ import React, {Component, Children} from "react";
 import {observer} from "mobx-react";
 import styled from "styled-components";
 import compact from "lodash/compact";
+import {setUrlValue, getUrlValue} from "../../stores/UrlManager";
 
 const TabsWrapper = styled.div`
   height: 100%;
@@ -54,13 +55,18 @@ let selectedTab = "";
 @observer
 class Tabs extends Component {
   state = {
-    selectedTab: "",
+    selectedTab: getUrlValue("tab"),
   };
 
   onTabClick = (selectName) => () => {
-    this.setState({
-      selectedTab: selectName,
-    });
+    this.setState(
+      {
+        selectedTab: selectName,
+      },
+      () => {
+        setUrlValue("tab", this.state.selectedTab);
+      }
+    );
   };
 
   render() {

--- a/src/helpers/inflate.js
+++ b/src/helpers/inflate.js
@@ -1,0 +1,15 @@
+import set from "lodash/set";
+
+// Given an onject with keys like "path.into.nested.object",
+// returns a new nested object that mirros the paths from the keys.
+
+export function inflate(obj) {
+  const inflatedObj = {};
+  const entries = Object.entries(obj);
+
+  for (const [path, val] of entries) {
+    set(inflatedObj, path, val);
+  }
+
+  return inflatedObj;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,15 +7,20 @@ import TimeStore from "./stores/TimeStore";
 import UIStore from "./stores/UIStore";
 import {Provider} from "mobx-react";
 import JourneyStore from "./stores/JourneyStore";
+import {getInitialUrlState} from "./stores/UrlManager";
 
 const root = document.getElementById("root");
+const initialState = getInitialUrlState();
 
-const {state, actions} = createStore({
-  Filters: FilterStore,
-  Time: TimeStore,
-  UI: UIStore,
-  Journey: JourneyStore,
-});
+const {state, actions} = createStore(
+  {
+    Filters: FilterStore,
+    Time: TimeStore,
+    UI: UIStore,
+    Journey: JourneyStore,
+  },
+  initialState
+);
 
 const render = () => {
   const Root = require("./Root").default;

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,10 @@ import TimeStore from "./stores/TimeStore";
 import UIStore from "./stores/UIStore";
 import {Provider} from "mobx-react";
 import JourneyStore from "./stores/JourneyStore";
-import {getInitialUrlState} from "./stores/UrlManager";
+import {getUrlState} from "./stores/UrlManager";
 
 const root = document.getElementById("root");
-const initialState = getInitialUrlState();
+const initialState = getUrlState();
 
 const {state, actions} = createStore(
   {

--- a/src/stores/FilterStore.js
+++ b/src/stores/FilterStore.js
@@ -2,7 +2,9 @@ import {extendObservable, action} from "mobx";
 import filterActions from "./filterActions";
 import mergeWithObservable from "../helpers/mergeWithObservable";
 import JourneyActions from "./journeyActions";
-import createHistory from "history/createBrowserHistory";
+import {inflate} from "../helpers/inflate";
+import pick from "lodash/pick";
+import merge from "lodash/merge";
 
 const emptyState = {
   date: "2018-05-07",
@@ -23,7 +25,10 @@ const emptyState = {
 };
 
 export default (state, initialState) => {
-  extendObservable(state, {...emptyState, ...initialState});
+  extendObservable(
+    state,
+    merge(emptyState, pick(inflate(initialState), ...Object.keys(emptyState)))
+  );
 
   const journeyActions = JourneyActions(state);
   const actions = filterActions(state);

--- a/src/stores/FilterStore.js
+++ b/src/stores/FilterStore.js
@@ -22,10 +22,8 @@ const emptyState = {
   },
 };
 
-export default (state) => {
-  const history = createHistory();
-
-  extendObservable(state, emptyState);
+export default (state, initialState) => {
+  extendObservable(state, {...emptyState, ...initialState});
 
   const journeyActions = JourneyActions(state);
   const actions = filterActions(state);
@@ -35,16 +33,6 @@ export default (state) => {
     journeyActions.setSelectedJourney(null);
     state.requestedJourneys.clear();
   });
-
-  const selectStopFromUrl = action((location) => {
-    const query = new URLSearchParams(location.search);
-
-    if (query.has("stop")) {
-      state.stop = query.get("stop");
-    }
-  });
-
-  selectStopFromUrl(history.location);
 
   return {
     ...actions,

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -1,7 +1,6 @@
 import {extendObservable, action, observable} from "mobx";
 import getJourneyId from "../helpers/getJourneyId";
 import createHistory from "history/createBrowserHistory";
-import TimeActions from "./timeActions";
 import FilterActions from "./filterActions";
 import moment from "moment-timezone";
 import journeyActions from "./journeyActions";
@@ -29,25 +28,22 @@ export default (state) => {
     }
   );
 
-  const timeActions = TimeActions(state);
   const filterActions = FilterActions(state);
   const actions = journeyActions(state);
 
   const selectJourneyFromUrl = action((location) => {
-    if (location.pathname.includes("journey")) {
-      const [
-        // The first two array elements are an empty string and the word "journey".
-        // We're not interested in those.
-        // eslint-disable-next-line no-unused-vars
-        _,
-        // eslint-disable-next-line no-unused-vars
-        __,
-        oday,
-        journey_start_time,
-        route_id,
-        direction_id,
-      ] = location.pathname.split("/");
+    const [
+      // The first two array elements are an empty string and the word "journey".
+      // eslint-disable-next-line no-unused-vars
+      _,
+      basePath,
+      oday,
+      journey_start_time,
+      route_id,
+      direction_id,
+    ] = location.pathname.split("/");
 
+    if (basePath === "journey") {
       const date = moment.tz(oday, "YYYYMMDD", "Europe/Helsinki");
 
       let dateStr = "";
@@ -56,9 +52,7 @@ export default (state) => {
       if (date.isValid()) {
         dateStr = date.format("YYYY-MM-DD");
         filterActions.setDate(dateStr);
-      }
 
-      if (date.isValid()) {
         const time = moment.tz(
           `${oday} ${journey_start_time}`,
           "YYYYMMDD HHmmss",
@@ -67,7 +61,6 @@ export default (state) => {
 
         if (time.isValid()) {
           timeStr = time.format("HH:mm:ss");
-          timeActions.setTime(timeStr);
         }
       }
 

--- a/src/stores/TimeStore.js
+++ b/src/stores/TimeStore.js
@@ -2,12 +2,13 @@ import {extendObservable, reaction, action} from "mobx";
 import moment from "moment";
 import timer from "../helpers/timer";
 import timeActions from "./timeActions";
+import get from "lodash/get";
 
 let timerHandle = null;
 
-export default (state) => {
+export default (state, initialState) => {
   extendObservable(state, {
-    time: "13:00:00",
+    time: get(initialState, "time", "13:00:00"),
     playing: false,
     timeIncrement: 5,
     marginMinutes: 5,

--- a/src/stores/UrlManager.js
+++ b/src/stores/UrlManager.js
@@ -20,7 +20,7 @@ export const setUrlValue = (key, val) => {
 export const getInitialUrlState = () => {
   const query = new URLSearchParams(history.location.search);
 
-  const initialState = Array.from(query.values()).reduce((obj, [key, val]) => {
+  const initialState = Array.from(query.entries()).reduce((obj, [key, val]) => {
     obj[key] = val;
     return obj;
   }, {});

--- a/src/stores/UrlManager.js
+++ b/src/stores/UrlManager.js
@@ -1,3 +1,4 @@
+import get from "lodash/get";
 import createHistory from "history/createBrowserHistory";
 
 const history = createHistory();
@@ -17,13 +18,18 @@ export const setUrlValue = (key, val) => {
   history.push({search: queryStr});
 };
 
-export const getInitialUrlState = () => {
+export const getUrlState = () => {
   const query = new URLSearchParams(history.location.search);
 
-  const initialState = Array.from(query.entries()).reduce((obj, [key, val]) => {
+  const urlState = Array.from(query.entries()).reduce((obj, [key, val]) => {
     obj[key] = val;
     return obj;
   }, {});
 
-  return initialState;
+  return urlState;
+};
+
+export const getUrlValue = (key) => {
+  const values = getUrlState();
+  return get(values, key, "");
 };

--- a/src/stores/UrlManager.js
+++ b/src/stores/UrlManager.js
@@ -1,9 +1,14 @@
 import get from "lodash/get";
+import invoke from "lodash/invoke";
+import fromPairs from "lodash/fromPairs";
 import createHistory from "history/createBrowserHistory";
 
 const history = createHistory();
 
-export const setUrlValue = (key, val) => {
+// Sets or changes an URL value. Use repalce by default,
+// as we don't need to grow the history stack. We're not
+// listening to the url anyway, so going back does nothing.
+export const setUrlValue = (key, val, historyAction = "replace") => {
   const query = new URLSearchParams(history.location.search);
 
   if (!val) {
@@ -15,17 +20,12 @@ export const setUrlValue = (key, val) => {
   }
 
   const queryStr = query.toString();
-  history.push({search: queryStr});
+  invoke(history, historyAction, {search: queryStr});
 };
 
 export const getUrlState = () => {
   const query = new URLSearchParams(history.location.search);
-
-  const urlState = Array.from(query.entries()).reduce((obj, [key, val]) => {
-    obj[key] = val;
-    return obj;
-  }, {});
-
+  const urlState = fromPairs(Array.from(query.entries()));
   return urlState;
 };
 

--- a/src/stores/UrlManager.js
+++ b/src/stores/UrlManager.js
@@ -1,0 +1,29 @@
+import createHistory from "history/createBrowserHistory";
+
+const history = createHistory();
+
+export const setUrlValue = (key, val) => {
+  const query = new URLSearchParams(history.location.search);
+
+  if (!val) {
+    query.delete(key);
+  } else if (query.has(key)) {
+    query.set(key, val);
+  } else {
+    query.append(key, val);
+  }
+
+  const queryStr = query.toString();
+  history.push({search: queryStr});
+};
+
+export const getInitialUrlState = () => {
+  const query = new URLSearchParams(history.location.search);
+
+  const initialState = Array.from(query.values()).reduce((obj, [key, val]) => {
+    obj[key] = val;
+    return obj;
+  }, {});
+
+  return initialState;
+};

--- a/src/stores/filterActions.js
+++ b/src/stores/filterActions.js
@@ -1,12 +1,9 @@
 import {action} from "mobx";
 import moment from "moment-timezone";
 import get from "lodash/get";
-import createHistory from "history/createBrowserHistory";
 import {setUrlValue} from "./UrlManager";
 
 const filterActions = (state) => {
-  const history = createHistory();
-
   // Make sure all dates are correctly formed.
   const setDate = action("Set date", (dateValue) => {
     let momentValue = !dateValue

--- a/src/stores/filterActions.js
+++ b/src/stores/filterActions.js
@@ -21,12 +21,13 @@ const filterActions = (state) => {
   const setStop = action("Set stop", (stop = "") => {
     // Either get the stopId prop or treat the stop arg as the stopId.
     state.stop = get(stop, "stopId", stop);
-    setUrlValue("stop", stop);
+    setUrlValue("stop", state.stop);
   });
 
   // The unique_vehicle_id we're interested in.
   const setVehicle = action("Set vehicle", (vehicleId) => {
     state.vehicle = vehicleId || "";
+    setUrlValue("vehicle", state.vehicle);
   });
 
   const setLine = action(
@@ -35,6 +36,8 @@ const filterActions = (state) => {
       state.line.lineId = lineId;
       state.line.dateBegin = dateBegin;
       state.line.dateEnd = dateEnd;
+
+      setUrlValue("line.lineId", state.line.lineId);
     }
   );
 
@@ -44,6 +47,9 @@ const filterActions = (state) => {
     state.route.dateBegin = get(route, "dateBegin", "");
     state.route.dateEnd = get(route, "dateEnd", "");
     state.route.originstopId = get(route, "originstopId", "");
+
+    setUrlValue("route.routeId", state.route.routeId);
+    setUrlValue("route.direction", state.route.direction);
 
     const routeLine = get(route, "line.nodes[0]", null);
 

--- a/src/stores/filterActions.js
+++ b/src/stores/filterActions.js
@@ -2,6 +2,7 @@ import {action} from "mobx";
 import moment from "moment-timezone";
 import get from "lodash/get";
 import createHistory from "history/createBrowserHistory";
+import {setUrlValue} from "./UrlManager";
 
 const filterActions = (state) => {
   const history = createHistory();
@@ -23,22 +24,7 @@ const filterActions = (state) => {
   const setStop = action("Set stop", (stop = "") => {
     // Either get the stopId prop or treat the stop arg as the stopId.
     state.stop = get(stop, "stopId", stop);
-
-    // The following will be replaced with a better
-    // URL management solution in a future PR.
-
-    const query = new URLSearchParams(history.location.search);
-
-    if (!stop) {
-      query.delete("stop");
-    } else if (query.has("stop")) {
-      query.set("stop", stop);
-    } else {
-      query.append("stop", stop);
-    }
-
-    const queryStr = query.toString();
-    history.push({search: queryStr});
+    setUrlValue("stop", stop);
   });
 
   // The unique_vehicle_id we're interested in.

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -138,7 +138,7 @@ export default (state) => {
       ) {
         state.selectedJourney = null;
         filters.setVehicle(null);
-        history.push("/");
+        history.push({pathname: "/"});
       } else if (hfpItem) {
         const journey = pickJourneyProps(hfpItem);
         state.selectedJourney = journey;
@@ -147,7 +147,7 @@ export default (state) => {
           filters.setVehicle(hfpItem.unique_vehicle_id);
         }
 
-        history.push(createJourneyPath(hfpItem));
+        history.push({pathname: createJourneyPath(hfpItem)});
       }
     }
   );

--- a/src/stores/timeActions.js
+++ b/src/stores/timeActions.js
@@ -1,7 +1,16 @@
 import {action} from "mobx";
+import {setUrlValue} from "./UrlManager";
+import debounce from "lodash/debounce";
 
 const timeActions = (state) => {
-  const setTime = action((timeValue) => (state.time = timeValue));
+  // Time might update frequently, so make sure that setting it
+  // in the url doesn't slow down the app.
+  const setUrlTime = debounce((time) => setUrlValue("time", time), 1000);
+
+  const setTime = action((timeValue) => {
+    state.time = timeValue;
+    setUrlTime(state.time);
+  });
 
   const setTimeIncrement = action(
     (timeIncrementValue) => (state.timeIncrement = timeIncrementValue)


### PR DESCRIPTION
Most app state properties are now represented in the URL, and reloading or sharing the URL should show an almost identical view from where you left, up to and including the map position.

Two things will override the map position: routes and stops. If either is selected, the map will center on it even if map state is present in the URL. Also, routes override stops, so if both are selected the map will center on the route.

The previous URL state fro a selected journey is still present and works as before with one change: the journey_start_time parameter will no longer set the selected time, it is just there to select the journey. Time has its own parameter in the new URL structure.