### PR TITLE
Keep journey selected when changing the day

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR ${WORK}
 # Install app dependencies
 COPY yarn.lock ${WORK}
 COPY package.json ${WORK}
-COPY patches/ ${WORK}/patches/
 RUN yarn
 
 COPY . ${WORK}

--- a/src/components/RouteHfpEvents.js
+++ b/src/components/RouteHfpEvents.js
@@ -74,10 +74,8 @@ class RouteHfpEvents extends React.Component {
     const {journeyId, route, date, time, skipCache = false} = journeyRequest;
 
     const currentFetchState = resolvedJourneyStates.get(journeyId);
-    if (
-      currentFetchState === journeyFetchStates.PENDING ||
-      currentFetchState === journeyFetchStates.RESOLVED
-    ) {
+
+    if (currentFetchState === journeyFetchStates.PENDING) {
       return;
     }
 

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -93,11 +93,14 @@ export default (state) => {
 
   selectJourneyFromUrl(getPathName());
 
+  // If a journey is selected, sync the day of the selected journey when the
+  // selected date changes.
   reaction(
     () => state.date,
     (currentDate) => {
       const currentlySelectedJourney = state.selectedJourney;
 
+      // No action if there is not a selected journey
       if (!currentlySelectedJourney) {
         return;
       }

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -1,10 +1,11 @@
-import {extendObservable, action, observable} from "mobx";
+import {extendObservable, action, observable, reaction, runInAction} from "mobx";
 import getJourneyId from "../helpers/getJourneyId";
 import FilterActions from "./filterActions";
 import moment from "moment-timezone";
 import journeyActions from "./journeyActions";
 import {pickJourneyProps} from "../helpers/pickJourneyProps";
 import {getPathName} from "./UrlManager";
+import get from "lodash/get";
 
 export const journeyFetchStates = {
   PENDING: "pending",
@@ -91,6 +92,25 @@ export default (state) => {
   });
 
   selectJourneyFromUrl(getPathName());
+
+  reaction(
+    () => state.date,
+    (currentDate) => {
+      const currentlySelectedJourney = state.selectedJourney;
+
+      if (!currentlySelectedJourney) {
+        return;
+      }
+
+      const journeyDate = get(currentlySelectedJourney, "oday", "");
+
+      if (journeyDate !== currentDate) {
+        runInAction(() => {
+          state.selectedJourney.oday = currentDate;
+        });
+      }
+    }
+  );
 
   return {
     ...actions,


### PR DESCRIPTION
Keeps journey selected when toggling between days. If the same journey is not available during the next day, it will remember the previous journey that was selected, and once the user returns to a day where it is available it will show as selected.

Also fixes a bug where journeys were not being displayed as fetched when returning to a previously visited day.