### PR TITLE
Fix timetable list

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "lodash": "^4.17.11",
     "mapbox-gl": "^0.52.0-beta.1",
     "mapillary-js": "^2.14.0",
-    "memoized-decorator": "^0.0.4",
     "mobx": "^5.7.0",
     "mobx-app": "^1.0.3",
     "mobx-react": "^5.4.2",

--- a/src/components/sidepanel/StopTimetable.js
+++ b/src/components/sidepanel/StopTimetable.js
@@ -111,7 +111,6 @@ class StopTimetable extends Component {
 
     return (
       <FirstDepartureQuery
-        key={`first_departure_query_${date}`}
         skip={batchedFirstDepartureRequests.length === 0}
         queries={batchedFirstDepartureRequests}
         dayType={dayType}>

--- a/src/components/sidepanel/StopTimetable.js
+++ b/src/components/sidepanel/StopTimetable.js
@@ -17,7 +17,7 @@ const TimetableSection = styled.div`
   margin-bottom: 1.5rem;
 `;
 
-export const AVG_DEPARTURES_THRESHOLD = 7;
+export const AVG_DEPARTURES_THRESHOLD = 20;
 
 @observer
 class StopTimetable extends Component {

--- a/src/components/sidepanel/StopTimetable.js
+++ b/src/components/sidepanel/StopTimetable.js
@@ -17,8 +17,6 @@ const TimetableSection = styled.div`
   margin-bottom: 1.5rem;
 `;
 
-export const AVG_DEPARTURES_THRESHOLD = 20;
-
 @observer
 class StopTimetable extends Component {
   // Finds a departure that is closest to the given time and returns its hours and minutes.
@@ -70,18 +68,13 @@ class StopTimetable extends Component {
     let {min, max} = timeRangeFilter;
 
     const dayType = getDayTypeFromDate(date);
-    let batchedFirstDepartureRequests = [];
 
-    // Only fetch the observed times if there's not too many departures. If the average
-    // number of departures per hour is over the threshold, wait for the user to filter by time.
-    if (departuresPerHour <= AVG_DEPARTURES_THRESHOLD || (min && max)) {
-      // Create batches for the firstDeparture query.
-      batchedFirstDepartureRequests = flatMap(
-        departuresByHour,
-        // Map to whole departures. The query will pick what it needs.
-        ([hour, departures]) => departures.map((dep) => dep)
-      );
-    }
+    // Create batches for the firstDeparture query.
+    let batchedFirstDepartureRequests = flatMap(
+      departuresByHour,
+      // Map to whole departures. The query will pick what it needs.
+      ([hour, departures]) => departures.map((dep) => dep)
+    );
 
     // If there is min/max hour filters set, make sure no unnecessary first departures are fetched.
     if (min || max || routeFilter) {

--- a/src/components/sidepanel/StopTimetable.js
+++ b/src/components/sidepanel/StopTimetable.js
@@ -111,6 +111,7 @@ class StopTimetable extends Component {
 
     return (
       <FirstDepartureQuery
+        key={`first_departure_query_${date}`}
         skip={batchedFirstDepartureRequests.length === 0}
         queries={batchedFirstDepartureRequests}
         dayType={dayType}>
@@ -141,7 +142,7 @@ class StopTimetable extends Component {
               }
 
               return (
-                <TimetableSection key={`hour_${stop.stopId}_${hour}`}>
+                <TimetableSection key={`hour_${stop.stopId}_${date}_${hour}`}>
                   {timetableDepartures.map((departure) => {
                     const {
                       departureId,
@@ -168,7 +169,7 @@ class StopTimetable extends Component {
                     if (firstDepartures && firstDepartureTime) {
                       departureJourney = get(
                         groupedJourneys,
-                        `${firstDepartureTime}:${departure.routeId}:${
+                        `${date}:${firstDepartureTime}:${departure.routeId}:${
                           departure.direction
                         }`,
                         null

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {observer, inject} from "mobx-react";
+import {observer, inject, Observer} from "mobx-react";
 import SidepanelList from "./SidepanelList";
 import StopTimetable, {AVG_DEPARTURES_THRESHOLD} from "./StopTimetable";
 import withStop from "../../hoc/withStop";
@@ -21,6 +21,7 @@ import memoize from "memoized-decorator";
 import {combineDateAndTime} from "../../helpers/time";
 import {createDebouncedObservable} from "../../helpers/createDebouncedObservable";
 import {getUrlValue, setUrlValue} from "../../stores/UrlManager";
+import getJourneyId from "../../helpers/getJourneyId";
 
 const RouteFilterContainer = styled.div`
   flex: 1 1 50%;
@@ -68,7 +69,7 @@ class TimetablePanel extends Component {
   getDefaultTimeRangeValue(timeRange, perHour, date, time) {
     let {min = "", max = ""} = timeRange;
 
-    if (!min && !max && perHour > AVG_DEPARTURES_THRESHOLD && perHour < 40) {
+    if (!min && !max && perHour > AVG_DEPARTURES_THRESHOLD) {
       const currentTime = combineDateAndTime(date, time, "Europe/Helsinki");
       // Use the average numbe of departures per hour to determine how large of a range to set.
       // More departures means narrower ranges, the idea is to not have the fetch take forever.
@@ -353,31 +354,30 @@ class TimetablePanel extends Component {
           return (
             stop && (
               <StopHfpQuery
+                key={`stop_hfp_${stop.stopId}_${date}`}
                 skip={routes.length === 0} // Skip if there are no routes to fetch
                 stopId={stop.stopId}
                 routes={routes}
                 directions={directions}
                 date={date}>
-                {({journeys, loading}) => {
-                  return (
-                    <StopTimetable
-                      key={`stop_timetable_${stop.stopId}_${date}`}
-                      loading={timetableLoading || loading}
-                      time={this.reactionlessTime}
-                      focusRef={scrollRef}
-                      setScrollOffset={updateScrollOffset}
-                      routeFilter={routeFilter}
-                      timeRangeFilter={timeRangeFilter}
-                      groupedJourneys={journeys}
-                      departuresByHour={departuresByHour}
-                      departuresPerHour={this.avgDeparturesPerHour}
-                      stop={stop}
-                      date={date}
-                      selectedJourney={selectedJourney}
-                      onSelectAsJourney={this.selectAsJourney}
-                    />
-                  );
-                }}
+                {({journeys, loading}) => (
+                  <StopTimetable
+                    key={`stop_timetable_${stop.stopId}_${date}`}
+                    loading={timetableLoading || loading}
+                    time={this.reactionlessTime}
+                    focusRef={scrollRef}
+                    setScrollOffset={updateScrollOffset}
+                    routeFilter={routeFilter}
+                    timeRangeFilter={timeRangeFilter}
+                    groupedJourneys={journeys}
+                    departuresByHour={departuresByHour}
+                    departuresPerHour={this.avgDeparturesPerHour}
+                    stop={stop}
+                    date={date}
+                    selectedJourney={selectedJourney}
+                    onSelectAsJourney={this.selectAsJourney}
+                  />
+                )}
               </StopHfpQuery>
             )
           );

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -16,7 +16,6 @@ import doubleDigit from "../../helpers/doubleDigit";
 import orderBy from "lodash/orderBy";
 import meanBy from "lodash/meanBy";
 import groupBy from "lodash/groupBy";
-import memoize from "memoized-decorator";
 import {combineDateAndTime} from "../../helpers/time";
 import {createDebouncedObservable} from "../../helpers/createDebouncedObservable";
 import {getUrlValue, setUrlValue} from "../../stores/UrlManager";

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -212,11 +212,9 @@ class TimetablePanel extends Component {
 
     // We query for the hfp data related to the routes and directions on
     // this stop in one go, instead of doing one query per row. Collect
-    // all distinct routes and directions in these arrays. Yes, there
-    // are stops with more than one direction.
-
-    let routes = [];
-    let directions = [];
+    // all distinct routes and directions in this map. Yes, there
+    // are stops with more than one direction. Routes are grouped by direction.
+    let routes = {};
 
     const {min, max} = timeRangeFilter;
 
@@ -242,15 +240,15 @@ class TimetablePanel extends Component {
         continue;
       }
 
-      // No need for more than one of everything
-      if (routes.indexOf(routeId) === -1) {
-        routes.push(routeId);
+      if (!routes[direction]) {
+        routes[direction] = [];
       }
 
-      const intDirection = parseInt(direction, 10);
+      const directionRoutes = routes[direction];
 
-      if (directions.indexOf(intDirection) === -1) {
-        directions.push(intDirection);
+      // Check that the route isn't already included.
+      if (directionRoutes.indexOf(routeId) === -1) {
+        directionRoutes.push(routeId);
       }
     }
 
@@ -297,7 +295,6 @@ class TimetablePanel extends Component {
                 skip={routes.length === 0} // Skip if there are no routes to fetch
                 stopId={stop.stopId}
                 routes={routes}
-                directions={directions}
                 date={date}>
                 {({journeys, loading}) => (
                   <StopTimetable

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -190,8 +190,17 @@ class TimetablePanel extends Component {
     let routes = [];
     let directions = [];
 
+    const {min, max} = timeRangeFilter;
+
     for (const departure of departures) {
-      const {routeId, direction} = departure;
+      const {routeId, direction, hours} = departure;
+
+      // If there is a timerange filter set, ignore routes
+      // from departures that fall outside the filter.
+      if ((min && hours < parseInt(min)) || (max && hours > parseInt(max))) {
+        continue;
+      }
+
       // Clean up the routeId to be compatible with what
       // the user will enter into the filter field.
       const routeIdFilterTerm = routeId

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -68,9 +68,9 @@ class TimetablePanel extends Component {
 
     if (!min && !max && perHour > AVG_DEPARTURES_THRESHOLD) {
       const currentTime = combineDateAndTime(date, time, "Europe/Helsinki");
-      // Use the average numbe of departures per hour to determine how large of a range to set.
+      // Use the average number of departures per hour to determine how large of a range to set.
       // More departures means narrower ranges, the idea is to not have the fetch take forever.
-      const hourModifier = perHour > 30 ? 2 : perHour > 20 ? 3 : 4;
+      const hourModifier = perHour > 40 ? 3 : perHour > 30 ? 4 : 5;
       const modifierHalf = Math.floor(hourModifier / 2);
 
       min = currentTime
@@ -207,19 +207,18 @@ class TimetablePanel extends Component {
     // This is used to determine if observed times can be fetched immediately,
     // or if we should wait for the user to filter the list. Filtering by
     // route should also be taken into account here.
-    return Math.round(
-      meanBy(departuresByHour, ([hour, hourDepartures]) => {
-        // The route filter will help to ease the burden of too many departures, so
-        // make sure that the average does not include routes that do not match the filter.
-        if (!routeFilter) {
-          return hourDepartures.length;
-        }
+    const avgPerHour = meanBy(departuresByHour, ([hour, hourDepartures]) => {
+      if (!routeFilter) {
+        return hourDepartures.length;
+      }
 
-        return hourDepartures.filter(
-          (departure) => departure.routeId === routeFilter
-        ).length;
-      })
-    );
+      // The route filter will help to ease the burden of too many departures, so
+      // make sure that the average does not include routes that do not match the filter.
+      return hourDepartures.filter((departure) => departure.routeId === routeFilter)
+        .length;
+    });
+
+    return Math.round(avgPerHour && !isNaN(avgPerHour) ? avgPerHour : 1);
   }
 
   getDeparturesByHour() {

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -6,7 +6,6 @@ import withStop from "../../hoc/withStop";
 import {app} from "mobx-app";
 import withAllStopDepartures from "../../hoc/withAllStopDepartures";
 import {toJS, computed, reaction} from "mobx";
-import {expr} from "mobx-utils";
 import styled from "styled-components";
 import Input from "../Input";
 import {text} from "../../helpers/text";
@@ -21,7 +20,6 @@ import memoize from "memoized-decorator";
 import {combineDateAndTime} from "../../helpers/time";
 import {createDebouncedObservable} from "../../helpers/createDebouncedObservable";
 import {getUrlValue, setUrlValue} from "../../stores/UrlManager";
-import getJourneyId from "../../helpers/getJourneyId";
 
 const RouteFilterContainer = styled.div`
   flex: 1 1 50%;
@@ -203,7 +201,7 @@ class TimetablePanel extends Component {
 
   @computed
   get avgDeparturesPerHour() {
-    const departuresByHour = this.getDeparturesByHour(this.departuresKey);
+    const departuresByHour = this.getDeparturesByHour();
     const routeFilter = this.routeFilter.debouncedValue;
 
     // Figure out how many departures this stop has planned per hour on average.
@@ -225,22 +223,7 @@ class TimetablePanel extends Component {
     );
   }
 
-  // Used when calling this.getDeparturesByHour as the memoization key.
-  get departuresKey() {
-    const {stop, date, departures} = this.props;
-
-    if (departures.length === 0) {
-      return "";
-    }
-
-    return `${get(stop, "stopId", stop)}_${date}`;
-  }
-
-  // This will get called a few times during updates, so it is memoized.
-  // Although the method itself does not use the argument, always pass
-  // this.departuresKey when calling it for the memoization to work.
-  @memoize
-  getDeparturesByHour(departuresKey) {
+  getDeparturesByHour() {
     const {departures} = this.props;
     // Group into hours while making sure to separate pre-4:30 and post-4:30 departures
     const byHour = groupBy(departures, ({hours, minutes}) => {
@@ -271,7 +254,7 @@ class TimetablePanel extends Component {
     // the per hour average number of departures is used to determine if we
     // allow the app to fetch data immediately or if we need to wait for filter input.
     const departuresPerHour = this.avgDeparturesPerHour;
-    const departuresByHour = this.getDeparturesByHour(this.departuresKey);
+    const departuresByHour = this.getDeparturesByHour();
 
     // We query for the hfp data related to the routes and directions on
     // this stop in one go, instead of doing one query per row. Collect

--- a/src/queries/FirstDepartureQuery.js
+++ b/src/queries/FirstDepartureQuery.js
@@ -123,6 +123,8 @@ class FirstDepartureQuery extends Component {
                 departure.departureId
               }`;
 
+              console.log(key);
+
               collection[key] = startTime;
               return collection;
             },

--- a/src/queries/FirstDepartureQuery.js
+++ b/src/queries/FirstDepartureQuery.js
@@ -123,8 +123,6 @@ class FirstDepartureQuery extends Component {
                 departure.departureId
               }`;
 
-              console.log(key);
-
               collection[key] = startTime;
               return collection;
             },

--- a/src/queries/StopHfpQuery.js
+++ b/src/queries/StopHfpQuery.js
@@ -59,7 +59,10 @@ class StopHfpQuery extends Component {
 
           const journeysByRoute = groupBy(
             get(data, "vehicles", []),
-            (hfp) => `${hfp.journey_start_time}:${hfp.route_id}:${hfp.direction_id}`
+            (hfp) =>
+              `${hfp.oday}:${hfp.journey_start_time}:${hfp.route_id}:${
+                hfp.direction_id
+              }`
           );
 
           const journeysByRouteAndTime = reduce(

--- a/src/stores/FilterStore.js
+++ b/src/stores/FilterStore.js
@@ -4,7 +4,6 @@ import JourneyActions from "./journeyActions";
 import {inflate} from "../helpers/inflate";
 import pick from "lodash/pick";
 import merge from "lodash/merge";
-import get from "lodash/get";
 import {resetUrlState} from "./UrlManager";
 
 const resetListeners = [];

--- a/src/stores/filterActions.js
+++ b/src/stores/filterActions.js
@@ -15,6 +15,7 @@ const filterActions = (state) => {
     }
 
     state.date = momentValue.format("YYYY-MM-DD");
+    setUrlValue("date", state.date);
   });
 
   // Grab the stopId from the passed stop object.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7234,13 +7234,6 @@ memoize-one@^4.0.0:
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
   integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
 
-memoized-decorator@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/memoized-decorator/-/memoized-decorator-0.0.4.tgz#118a409ff7320332d5e787c29b6032e363259687"
-  integrity sha512-Gcs6NqJNAxgCaubU30dOa8ZbMDOxLalND7D9/VkqSTqUe80X+uiDP1Cj+khBcK01i5RhQIfNqcji9CxtPb1AZw==
-  dependencies:
-    serialize-javascript "^1.4.0"
-
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"


### PR DESCRIPTION
Fixes many issues and bugs in the timetable list. I also noticed that the FirstDepartures fetch from JORE is now a lot faster, so we can remove all automatic filter values and filtering requirements.

- Fix wrong departures shown when switching between days
- Add reset button for timetable filters
- Also reset timetable filters when the app resets
- Add the date to URL state (previously this was supposed to work through the path, like /journey/2018-12-14 etc)
- Remove automatic timerange filter values
- Remove all filter requirements
- If there is a timerange filter set, only fetch HFP data for the routes that have departures within that timetange