### PR TITLE
Show stop radius

### DIFF
--- a/src/components/map/LeafletMap.js
+++ b/src/components/map/LeafletMap.js
@@ -1,5 +1,12 @@
 import React, {Component} from "react";
-import {Map, TileLayer, ZoomControl, Pane, LayersControl} from "react-leaflet";
+import {
+  Map,
+  TileLayer,
+  ZoomControl,
+  Pane,
+  LayersControl,
+  FeatureGroup,
+} from "react-leaflet";
 import {latLng} from "leaflet";
 import get from "lodash/get";
 import MapillaryViewer from "./MapillaryViewer";
@@ -7,6 +14,8 @@ import styled from "styled-components";
 import "leaflet/dist/leaflet.css";
 import MapillaryGeoJSONLayer from "./MapillaryGeoJSONLayer";
 import {setUrlValue, getUrlValue} from "../../stores/UrlManager";
+import {observer, inject} from "mobx-react";
+import {app} from "mobx-app";
 
 const MapContainer = styled.div`
   width: 100%;
@@ -31,10 +40,11 @@ const MapillaryView = styled(MapillaryViewer)`
   position: relative;
 `;
 
+@inject(app("UI"))
+@observer
 class LeafletMap extends Component {
   state = {
     currentBaseLayer: getUrlValue("mapBaseLayer", "Digitransit"),
-    currentOverlays: getUrlValue("mapOverlays", "").split(","),
     currentMapillaryMapLocation: false,
   };
 
@@ -43,34 +53,6 @@ class LeafletMap extends Component {
 
     this.setState({
       currentBaseLayer: name,
-    });
-  };
-
-  onChangeOverlay = (action) => ({name}) => {
-    const overlays = this.state.currentOverlays;
-
-    if (action === "remove") {
-      // Be sure to hide the Mapillary viewer if the mapillary layer was turned off.
-      if (name === "Mapillary") {
-        this.props.setMapillaryViewerLocation(false);
-      }
-
-      const idx = overlays.indexOf(name);
-
-      if (idx !== -1) {
-        overlays.splice(idx, 1);
-      }
-    } else if (action === "add") {
-      overlays.push(name);
-    }
-
-    setUrlValue(
-      "mapOverlays",
-      overlays.length !== 0 ? overlays.filter((name) => !!name).join(",") : null
-    );
-
-    this.setState({
-      currentOverlays: overlays,
     });
   };
 
@@ -84,6 +66,8 @@ class LeafletMap extends Component {
 
   render() {
     const {
+      state: {mapOverlays},
+      UI: {changeOverlay},
       mapRef,
       children,
       className,
@@ -94,11 +78,7 @@ class LeafletMap extends Component {
       onMapChanged = () => {},
     } = this.props;
 
-    const {
-      currentBaseLayer,
-      currentMapillaryMapLocation,
-      currentOverlays,
-    } = this.state;
+    const {currentBaseLayer, currentMapillaryMapLocation} = this.state;
 
     return (
       <MapContainer className={className}>
@@ -109,8 +89,8 @@ class LeafletMap extends Component {
           selectArea={true}
           zoomControl={false}
           onBaselayerchange={this.onChangeBaseLayer}
-          onOverlayadd={this.onChangeOverlay("add")}
-          onOverlayremove={this.onChangeOverlay("remove")}
+          onOverlayadd={changeOverlay("add")}
+          onOverlayremove={changeOverlay("remove")}
           onZoomend={onZoom}
           onMoveend={onMapChanged}>
           <LayersControl position="topright">
@@ -136,14 +116,24 @@ class LeafletMap extends Component {
             </LayersControl.BaseLayer>
             <LayersControl.Overlay
               name="Mapillary"
-              checked={currentOverlays.indexOf("Mapillary") !== -1}>
+              checked={mapOverlays.indexOf("Mapillary") !== -1}>
               <MapillaryGeoJSONLayer
                 map={get(mapRef, "current.leafletElement", null)}
                 viewBbox={viewBbox}
                 location={currentMapillaryMapLocation}
-                layerIsActive={currentOverlays.indexOf("Mapillary") !== -1}
+                layerIsActive={mapOverlays.indexOf("Mapillary") !== -1}
                 onSelectLocation={setMapillaryViewerLocation}
               />
+            </LayersControl.Overlay>
+            <LayersControl.Overlay
+              name="Stop radius"
+              checked={mapOverlays.indexOf("Stop radius") !== -1}>
+              <FeatureGroup>
+                {/*
+                  The stop radius is rendered in the StopMarker component. This featuregroup
+                  is just a dummy so that the option will show in the layer control.
+                */}
+              </FeatureGroup>
             </LayersControl.Overlay>
           </LayersControl>
           <Pane name="mapillary-lines" style={{zIndex: 390}} />

--- a/src/components/map/MapContent.js
+++ b/src/components/map/MapContent.js
@@ -12,6 +12,7 @@ import HfpMarkerLayer from "./HfpMarkerLayer";
 import {app} from "mobx-app";
 import RouteStopsLayer from "./RouteStopsLayer";
 import AreaSelect from "./AreaSelect";
+import {expr} from "mobx-utils";
 
 @inject(app("Journey", "Filters"))
 @observer
@@ -35,10 +36,11 @@ class MapContent extends Component {
       setMapBounds,
       viewLocation,
       queryBounds,
-      state: {vehicle, selectedJourney, date},
+      state: {vehicle, selectedJourney, date, mapOverlays},
     } = this.props;
 
     const hasRoute = !!route && !!route.routeId;
+    const showStopRadius = expr(() => mapOverlays.indexOf("Stop radius") !== -1);
 
     return (
       <>
@@ -47,12 +49,14 @@ class MapContent extends Component {
           <>
             {zoom > 14 ? (
               <StopLayer
+                showRadius={showStopRadius}
                 onViewLocation={viewLocation}
                 date={date}
                 bounds={stopsBbox}
               />
             ) : stop ? (
               <StopMarker
+                showRadius={showStopRadius}
                 onViewLocation={viewLocation}
                 stop={stop}
                 selected={true}

--- a/src/components/map/StopLayer.js
+++ b/src/components/map/StopLayer.js
@@ -1,12 +1,20 @@
 import React, {Component} from "react";
-import {observer} from "mobx-react";
+import {observer, inject} from "mobx-react";
 import StopsByBboxQuery from "../../queries/StopsByBboxQuery";
 import StopMarker from "./StopMarker";
+import {app} from "mobx-app";
+import {expr} from "mobx-utils";
 
+@inject(app("state"))
 @observer
 class StopLayer extends Component {
   render() {
-    const {bounds, date, onViewLocation} = this.props;
+    const {
+      state: {mapOverlays},
+      bounds,
+      date,
+      onViewLocation,
+    } = this.props;
 
     const bbox = {
       minLat: bounds.getSouth(),
@@ -15,11 +23,14 @@ class StopLayer extends Component {
       maxLon: bounds.getEast(),
     };
 
+    const showRadius = expr(() => mapOverlays.indexOf("Stop radius") !== -1);
+
     return (
       <StopsByBboxQuery variables={{...bbox, date}}>
         {({stops}) =>
           stops.map((stop) => (
             <StopMarker
+              showRadius={showRadius}
               onViewLocation={onViewLocation}
               key={`stops_${stop.stopId}`}
               stop={stop}

--- a/src/components/map/StopLayer.js
+++ b/src/components/map/StopLayer.js
@@ -1,20 +1,12 @@
 import React, {Component} from "react";
-import {observer, inject} from "mobx-react";
+import {observer} from "mobx-react";
 import StopsByBboxQuery from "../../queries/StopsByBboxQuery";
 import StopMarker from "./StopMarker";
-import {app} from "mobx-app";
-import {expr} from "mobx-utils";
 
-@inject(app("state"))
 @observer
 class StopLayer extends Component {
   render() {
-    const {
-      state: {mapOverlays},
-      bounds,
-      date,
-      onViewLocation,
-    } = this.props;
+    const {bounds, date, onViewLocation, showRadius} = this.props;
 
     const bbox = {
       minLat: bounds.getSouth(),
@@ -22,8 +14,6 @@ class StopLayer extends Component {
       maxLat: bounds.getNorth(),
       maxLon: bounds.getEast(),
     };
-
-    const showRadius = expr(() => mapOverlays.indexOf("Stop radius") !== -1);
 
     return (
       <StopsByBboxQuery variables={{...bbox, date}}>

--- a/src/components/map/StopMarker.js
+++ b/src/components/map/StopMarker.js
@@ -1,12 +1,13 @@
 import React, {Component} from "react";
 import {observer, inject} from "mobx-react";
-import {Popup, CircleMarker, Circle} from "react-leaflet";
+import {Popup, CircleMarker} from "react-leaflet";
 import {latLng} from "leaflet";
 import {Heading} from "../Typography";
 import get from "lodash/get";
 import styled from "styled-components";
 import {app} from "mobx-app";
 import {getPriorityMode, getModeColor} from "../../helpers/vehicleColor";
+import {StopRadius} from "./StopRadius";
 
 const StopRouteList = styled.button`
   text-decoration: none;
@@ -84,16 +85,9 @@ class StopMarker extends Component {
     );
 
     return showRadius ? (
-      <Circle
-        center={markerPosition}
-        weight={1}
-        opacity={0.5}
-        color={stopColor}
-        fillColor={stopColor}
-        fillOpacity={0.15}
-        radius={stopRadius}>
+      <StopRadius center={markerPosition} color={stopColor} radius={stopRadius}>
         {markerElement}
-      </Circle>
+      </StopRadius>
     ) : (
       markerElement
     );

--- a/src/components/map/StopMarker.js
+++ b/src/components/map/StopMarker.js
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 import {observer, inject} from "mobx-react";
-import {Popup, CircleMarker} from "react-leaflet";
+import {Popup, CircleMarker, Circle} from "react-leaflet";
 import {latLng} from "leaflet";
 import {Heading} from "../Typography";
 import get from "lodash/get";
@@ -42,17 +42,20 @@ class StopMarker extends Component {
   };
 
   render() {
-    const {stop, state} = this.props;
+    const {stop, state, showRadius = true} = this.props;
     const {stop: selectedStop} = state;
 
     const selected = selectedStop === stop.stopId;
     const mode = getPriorityMode(get(stop, "modes.nodes", []));
     const stopColor = getModeColor(mode);
+    const {stopRadius} = stop;
 
-    return (
+    const markerPosition = [stop.lat, stop.lon];
+
+    const markerElement = (
       <CircleMarker
         pane="stops"
-        center={[stop.lat, stop.lon]}
+        center={markerPosition}
         color={stopColor}
         fillColor={selected ? stopColor : "white"}
         fillOpacity={1}
@@ -78,6 +81,21 @@ class StopMarker extends Component {
           <button onClick={this.onShowStreetView}>Show in street view</button>
         </Popup>
       </CircleMarker>
+    );
+
+    return showRadius ? (
+      <Circle
+        center={markerPosition}
+        weight={1}
+        opacity={0.5}
+        color={stopColor}
+        fillColor={stopColor}
+        fillOpacity={0.15}
+        radius={stopRadius}>
+        {markerElement}
+      </Circle>
+    ) : (
+      markerElement
     );
   }
 }

--- a/src/components/map/StopRadius.js
+++ b/src/components/map/StopRadius.js
@@ -1,0 +1,17 @@
+import {Circle} from "react-leaflet";
+import React from "react";
+
+export function StopRadius({center, radius, children, color}) {
+  return (
+    <Circle
+      center={center}
+      weight={1}
+      opacity={0.33}
+      color={color}
+      fillColor={color}
+      fillOpacity={0.1}
+      radius={radius}>
+      {children}
+    </Circle>
+  );
+}

--- a/src/components/transportModes.js
+++ b/src/components/transportModes.js
@@ -19,11 +19,11 @@ export const transportColor = {
 };
 
 export const TransportIcon = ({mode = ""}) => {
-  if (!mode || typeof mode !== "string") {
+  if (!mode || typeof mode !== "string" || !get(transportIcons, mode, false)) {
     return null;
   }
 
-  return React.createElement(get(transportIcons, mode, null), {
+  return React.createElement(get(transportIcons, mode), {
     fill: get(transportColor, mode, "var(--light-grey)"),
     width: "16",
     height: "16",

--- a/src/queries/AllStopsQuery.js
+++ b/src/queries/AllStopsQuery.js
@@ -13,6 +13,7 @@ const allStopsQuery = gql`
         lat
         lon
         nameFi
+        stopRadius
         __typename
       }
     }

--- a/src/queries/StopFieldsFragment.js
+++ b/src/queries/StopFieldsFragment.js
@@ -9,6 +9,7 @@ export const StopFieldsFragment = gql`
     lon
     shortId
     nameFi
+    stopRadius
     modes {
       nodes
     }
@@ -23,6 +24,7 @@ export const StopFieldsWithRouteSegmentsFragment = gql`
     lon
     shortId
     nameFi
+    stopRadius
     modes {
       nodes
     }

--- a/src/queries/StopsByBboxQuery.js
+++ b/src/queries/StopsByBboxQuery.js
@@ -21,6 +21,7 @@ const stopsByBboxQuery = gql`
         nameFi
         lat
         lon
+        stopRadius
         modes {
           nodes
         }

--- a/src/stores/UIStore.js
+++ b/src/stores/UIStore.js
@@ -1,4 +1,5 @@
 import {extendObservable, action, observable, reaction} from "mobx";
+import {getUrlValue, setUrlValue} from "./UrlManager";
 
 export const LANGUAGES = {
   FINNISH: "fi",
@@ -13,6 +14,7 @@ export const languageState = observable({
 export default (state) => {
   extendObservable(state, {
     filterPanelVisible: true,
+    mapOverlays: getUrlValue("mapOverlays", "").split(","),
     language: languageState.language,
   });
 
@@ -26,6 +28,34 @@ export default (state) => {
     }
   });
 
+  const changeOverlay = (changeAction) =>
+    action(({name}) => {
+      const overlays = state.mapOverlays;
+
+      if (changeAction === "remove") {
+        /* TODO: fix this
+      // Be sure to hide the Mapillary viewer if the mapillary layer was turned off.
+      if( name === "Mapillary" ) {
+        this.props.setMapillaryViewerLocation(false);
+      }*/
+
+        const idx = overlays.indexOf(name);
+
+        if (idx !== -1) {
+          overlays.splice(idx, 1);
+        }
+      } else if (changeAction === "add") {
+        overlays.push(name);
+      }
+
+      setUrlValue(
+        "mapOverlays",
+        overlays.length !== 0 ? overlays.filter((name) => !!name).join(",") : null
+      );
+
+      state.mapOverlays.replace(overlays);
+    });
+
   // Sync external languageState with app state.
   reaction(
     () => languageState.language,
@@ -37,5 +67,6 @@ export default (state) => {
   return {
     toggleFilterPanel,
     setLanguage,
+    changeOverlay,
   };
 };


### PR DESCRIPTION
Adds the stop radius of all stops to the map. I also needed to move the overlay state from the LeafletMap component's local state into the UI state since the stop marker is rendered so far from the LeafletMap component. React-Leaflet requires that a leaflet element is returned from the LayersControl component, so I added a dummy FeatureGroup in order for the stop radius option to show.