### PR TITLE
Fix route stop radius

### DIFF
--- a/src/components/map/MapContent.js
+++ b/src/components/map/MapContent.js
@@ -101,6 +101,7 @@ class MapContent extends Component {
               (selectedJourney.route_id !== route.routeId ||
                 positions.length === 0)) && (
               <RouteStopsLayer
+                showRadius={showStopRadius}
                 onViewLocation={viewLocation}
                 route={route}
                 positions={[]}
@@ -129,6 +130,7 @@ class MapContent extends Component {
                   ) : null,
                   isSelectedJourney ? (
                     <RouteStopsLayer
+                      showRadius={showStopRadius}
                       onViewLocation={viewLocation}
                       key={`journey_stops_${journeyId}`}
                       route={route}

--- a/src/components/map/RouteStopMarker.js
+++ b/src/components/map/RouteStopMarker.js
@@ -65,7 +65,7 @@ class RouteStopMarker extends React.Component {
     );
 
     return showRadius ? (
-      <StopRadius center={markerPosition} radius={stop.stopRadius} color={color}>
+      <StopRadius center={markerPosition} radius={stop.stopRadius} color={stopColor}>
         {markerElement}
       </StopRadius>
     ) : (

--- a/src/components/map/RouteStopsLayer.js
+++ b/src/components/map/RouteStopsLayer.js
@@ -29,6 +29,7 @@ class RouteStopsLayer extends Component {
       route,
       state: {date, selectedJourney},
       onViewLocation,
+      showRadius,
     } = this.props;
 
     return (
@@ -45,6 +46,7 @@ class RouteStopsLayer extends Component {
         onViewLocation={onViewLocation}
         routeOriginStopId={get(route, "originstopId", "")}
         onSelect={this.onSelectStop(stop.stopId)}
+        showRadius={showRadius}
       />
     );
   };

--- a/src/components/map/StopRadius.js
+++ b/src/components/map/StopRadius.js
@@ -9,7 +9,7 @@ export function StopRadius({center, radius, children, color}) {
       opacity={0.33}
       color={color}
       fillColor={color}
-      fillOpacity={0.1}
+      fillOpacity={0.133}
       radius={radius}>
       {children}
     </Circle>


### PR DESCRIPTION
I noticed that although route stops can show radius, they never got the prop that determined if they should show it or not. I also fixed the color, so that it uses the color of the stop mode instead of the latency color.