### PR TITLE
Default to the current date

### DIFF
--- a/src/stores/FilterStore.js
+++ b/src/stores/FilterStore.js
@@ -5,6 +5,7 @@ import {inflate} from "../helpers/inflate";
 import pick from "lodash/pick";
 import merge from "lodash/merge";
 import {resetUrlState} from "./UrlManager";
+import {timeToFormat} from "../helpers/time";
 
 const resetListeners = [];
 
@@ -22,7 +23,7 @@ export function setResetListener(cb) {
 
 export default (state, initialState) => {
   const emptyState = {
-    date: "2018-05-07",
+    date: timeToFormat(new Date(), "YYYY-MM-DD", "Europe/Helsinki"),
     stop: "",
     vehicle: "",
     line: {


### PR DESCRIPTION
Defaults the date selection to the current date since the HFP API now contains current events.