### PR TITLE
Better time input

### DIFF
--- a/src/components/filterbar/TimeSettings.js
+++ b/src/components/filterbar/TimeSettings.js
@@ -5,6 +5,8 @@ import {combineDateAndTime} from "../../helpers/time";
 import {InputBase, ControlGroup} from "../Forms";
 import PlusMinusInput from "../PlusMinusInput";
 import styled from "styled-components";
+import doubleDigit from "../../helpers/doubleDigit";
+import {observable, action, computed} from "mobx";
 
 const TimeInput = styled(InputBase)`
   text-align: center;
@@ -16,6 +18,18 @@ const TimeInput = styled(InputBase)`
 @inject(app("Time"))
 @observer
 class TimeSettings extends Component {
+  @observable
+  timeInput = "";
+
+  @observable
+  isDirty = false;
+
+  @computed
+  get displayTime() {
+    const {time} = this.props.state;
+    return this.isDirty ? this.timeInput : time;
+  }
+
   onTimeButtonClick = (modifier) => () => {
     const {
       state: {date, time},
@@ -28,16 +42,51 @@ class TimeSettings extends Component {
     Time.setTime(nextTime);
   };
 
+  setTimeValue = action((value, dirtyVal = true) => {
+    this.timeInput = value;
+    this.isDirty = dirtyVal;
+  });
+
+  onBlur = () => {
+    const {Time} = this.props;
+    const timeValue = this.timeInput.replace(/([^0-9])+/g, "");
+
+    let hours = timeValue.slice(0, 2).trim() || "00";
+    let minutes = timeValue.slice(2, 4).trim() || "00";
+
+    if (parseInt(hours, 10) > 23) {
+      hours = timeValue.slice(0, 1).trim() || "0";
+      minutes = timeValue.slice(1, 3).trim() || "00";
+    }
+
+    function padMinutes(min) {
+      return min.length < 2 ? doubleDigit(min, true) : min;
+    }
+
+    if (parseInt(padMinutes(minutes), 10) > 59) {
+      minutes = "59";
+    }
+
+    const nextTimeVal = `${doubleDigit(hours)}:${padMinutes(minutes)}:00`;
+
+    Time.setTime(nextTimeVal, true);
+    this.setTimeValue("", false);
+  };
+
   render() {
-    const {state, Time} = this.props;
-    const {time, timeIncrement} = state;
+    const {state} = this.props;
+    const {timeIncrement} = state;
 
     return (
       <ControlGroup>
         <PlusMinusInput
           onIncrease={this.onTimeButtonClick(timeIncrement)}
           onDecrease={this.onTimeButtonClick(-timeIncrement)}>
-          <TimeInput value={time} onChange={(e) => Time.setTime(e.target.value)} />
+          <TimeInput
+            value={this.displayTime}
+            onBlur={this.onBlur}
+            onChange={(e) => this.setTimeValue(e.target.value, true)}
+          />
         </PlusMinusInput>
       </ControlGroup>
     );

--- a/src/helpers/doubleDigit.js
+++ b/src/helpers/doubleDigit.js
@@ -1,2 +1,5 @@
-const doubleDigit = (val) => ("0" + val).slice(-2);
+const doubleDigit = (val, padEnd = false) => {
+  const padded = !padEnd ? "0" + val : val + "0";
+  return padded.slice(-2);
+};
 export default doubleDigit;

--- a/src/stores/timeActions.js
+++ b/src/stores/timeActions.js
@@ -7,9 +7,14 @@ const timeActions = (state) => {
   // in the url doesn't slow down the app.
   const setUrlTime = debounce((time) => setUrlValue("time", time), 1000);
 
-  const setTime = action((timeValue) => {
+  const setTime = action((timeValue, setUrlImmediately = false) => {
     state.time = timeValue;
-    setUrlTime(state.time);
+
+    if (!setUrlImmediately) {
+      setUrlTime(state.time);
+    } else {
+      setUrlValue("time", state.time);
+    }
   });
 
   const setTimeIncrement = action(


### PR DESCRIPTION
Parse number strings to time in the time input. This allows the user to enter something like 123 and have the time set to 12:30. Non-number characters are removed, so "asd 123" will also result in 12:30.

By default the the first two digits are parsed as the hour and the next two digits are parsed as the minutes. If the hour value is larger than 23, only the first digit is assigned as the hour and the next two are the minutes. Also, if the minutes are over 59 they will be assigned to 59. Minutes are padded with zeroes at the end, so if the user intended to enter a < 10 minute value, they need to prepend a zero.

The parsing will be done and the resulting time will be assigned to the state time prop when the time input is blurred.