### PR TITLE
Journey details fixes and updates

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -8,8 +8,6 @@ import DevTools from "mobx-react-devtools";
 import {configureDevtool} from "mobx-react-devtools";
 import {GlobalFormStyle} from "./components/Forms";
 import {app} from "mobx-app";
-import Loading from "./components/Loading";
-import {observable, runInAction} from "mobx";
 
 configureDevtool({
   logEnabled: false,
@@ -22,25 +20,12 @@ configureDevtool({
 @inject(app("UI"))
 @observer
 class Root extends React.Component {
-  @observable
-  clientLoaded = false;
-
-  client = null;
-
-  async componentWillMount() {
-    const {UI} = this.props;
-    this.client = await getClient(UI);
-
-    runInAction(() => (this.clientLoaded = true));
-  }
-
   render() {
-    if (!this.clientLoaded || !this.client) {
-      return <Loading />;
-    }
+    const {UI} = this.props;
+    const client = getClient(UI);
 
     return (
-      <ApolloProvider client={this.client}>
+      <ApolloProvider client={client}>
         <>
           <GlobalFormStyle />
           <App />

--- a/src/Root.js
+++ b/src/Root.js
@@ -8,6 +8,8 @@ import DevTools from "mobx-react-devtools";
 import {configureDevtool} from "mobx-react-devtools";
 import {GlobalFormStyle} from "./components/Forms";
 import {app} from "mobx-app";
+import Loading from "./components/Loading";
+import {observable, runInAction} from "mobx";
 
 configureDevtool({
   logEnabled: false,
@@ -20,13 +22,25 @@ configureDevtool({
 @inject(app("UI"))
 @observer
 class Root extends React.Component {
-  render() {
-    const {UI} = this.props;
+  @observable
+  clientLoaded = false;
 
-    const client = getClient(UI);
+  client = null;
+
+  async componentWillMount() {
+    const {UI} = this.props;
+    this.client = await getClient(UI);
+
+    runInAction(() => (this.clientLoaded = true));
+  }
+
+  render() {
+    if (!this.clientLoaded || !this.client) {
+      return <Loading />;
+    }
 
     return (
-      <ApolloProvider client={client}>
+      <ApolloProvider client={this.client}>
         <>
           <GlobalFormStyle />
           <App />

--- a/src/api.js
+++ b/src/api.js
@@ -8,9 +8,6 @@ import {onError} from "apollo-link-error";
 import localforage from "localforage";
 import get from "lodash/get";
 
-const SCHEMA_VERSION = "1"; // Must be a string.
-const SCHEMA_VERSION_KEY = "apollo-schema-version";
-
 const joreUrl = process.env.REACT_APP_JORE_GRAPHQL_URL;
 const hfpUrl = process.env.REACT_APP_HFP_GRAPHQL_URL;
 
@@ -24,7 +21,7 @@ if (!hfpUrl) {
 
 let createdClient = null;
 
-export const getClient = async (UIStore) => {
+export const getClient = (UIStore) => {
   if (createdClient) {
     return createdClient;
   }
@@ -51,35 +48,6 @@ export const getClient = async (UIStore) => {
   });
 
   const cache = new InMemoryCache();
-
-  const cacheStorage = localforage.createInstance({
-    name: "transitlogStorage",
-    storeName: "transitlog_storage",
-    driver: localforage.INDEXEDDB,
-    size: 10000000000,
-  });
-
-  const persistor = new CachePersistor({
-    cache: cache,
-    storage: cacheStorage,
-    serialize: false,
-    key: "persisted_transitlog_cache",
-    maxSize: 10000000000, // 4 gb
-  });
-
-  // Read the current schema version from AsyncStorage.
-  const currentVersion = await localforage.getItem(SCHEMA_VERSION_KEY);
-
-  if (currentVersion === SCHEMA_VERSION) {
-    // If the current version matches the latest version,
-    // we're good to go and can restore the cache.
-    await persistor.restore();
-  } else {
-    // Otherwise, we'll want to purge the outdated persisted cache
-    // and mark ourselves as having updated to the latest version.
-    await persistor.purge();
-    await localforage.setItem(SCHEMA_VERSION_KEY, SCHEMA_VERSION);
-  }
 
   const joreLink = new BatchHttpLink({
     uri: joreUrl,

--- a/src/components/sidepanel/journeyDetails/Equipment.js
+++ b/src/components/sidepanel/journeyDetails/Equipment.js
@@ -23,7 +23,7 @@ export default ({journey, departure}) => {
   const {owner_operator_id, vehicle_number} = journey;
 
   const operatorId = (owner_operator_id + "").padStart(4, "0");
-  const vehicleId = (vehicle_number + "").padStart(4, "0");
+  const vehicleId = vehicle_number.toString();
 
   return (
     <EquipmentQuery vehicleId={vehicleId} operatorId={operatorId}>

--- a/src/components/sidepanel/journeyDetails/Equipment.js
+++ b/src/components/sidepanel/journeyDetails/Equipment.js
@@ -35,6 +35,10 @@ export default ({journey, departure}) => {
         return (
           <EquipmentWrapper>
             {map(equipmentRequirements, ({observed, required}, prop) => {
+              if (!observed) {
+                return null;
+              }
+
               const isRequired = required !== false;
 
               const color = isRequired

--- a/src/components/sidepanel/journeyDetails/Equipment.js
+++ b/src/components/sidepanel/journeyDetails/Equipment.js
@@ -34,9 +34,9 @@ export default ({journey, departure}) => {
 
         return (
           <EquipmentWrapper>
-            <span>{vehicle.class}</span>,{" "}
             {map(equipmentRequirements, ({observed, required}, prop) => {
               const isRequired = required !== false;
+
               const color = isRequired
                 ? observed === required
                   ? "var(--light-green)"

--- a/src/components/sidepanel/journeyDetails/JourneyInfo.js
+++ b/src/components/sidepanel/journeyDetails/JourneyInfo.js
@@ -4,7 +4,7 @@ import get from "lodash/get";
 import Equipment from "./Equipment";
 import CalculateTerminalTime from "./CalculateTerminalTime";
 import doubleDigit from "../../../helpers/doubleDigit";
-import {getEquipmentType, getFeature} from "./equipmentType";
+import {getEquipmentType} from "./equipmentType";
 
 const JourneyInfo = styled.div`
   flex: none;
@@ -49,8 +49,6 @@ export default ({
   const equipment = <Equipment journey={journey} departure={departure} />;
   const equipmentType = getEquipmentType(departure.equipmentType);
 
-  console.log(originStopTimes.departure);
-
   return (
     <JourneyInfo>
       {originStopTimes && (
@@ -65,7 +63,7 @@ export default ({
                 date={date}
                 departure={originStopTimes.departure}
                 event={originStopTimes.arrivalEvent}>
-                {({diffMinutes, diffSeconds, wasLate, sign}) => (
+                {({diffMinutes, diffSeconds, wasLate}) => (
                   <strong style={{color: wasLate ? "var(--red)" : "inherit"}}>
                     {doubleDigit(diffMinutes)}:{doubleDigit(diffSeconds)}
                   </strong>
@@ -73,6 +71,10 @@ export default ({
               </CalculateTerminalTime>
             </Line>
           </JourneyInfoRow>
+        </>
+      )}
+      {destinationStopTimes && (
+        <>
           <JourneyInfoRow>
             <Line>
               <span>Recovery time</span>
@@ -97,17 +99,10 @@ export default ({
       )}
       <JourneyInfoRow>
         <Line>
+          <span>Equipment required</span>
           <span>
-            Equipment {departure.equipmentRequired ? "required" : "planned"}
-          </span>
-          <span>
-            {equipmentType ? (
-              <>
-                {equipmentType} ({getFeature(equipmentType)})
-              </>
-            ) : (
-              "No data"
-            )}
+            {equipmentType ? <>{equipmentType}</> : "No type"}
+            {departure.trunkColorRequired === 1 && <>, HSL-orans</>}
           </span>
         </Line>
         {equipment && <Line right>{equipment}</Line>}

--- a/src/components/sidepanel/journeyDetails/JourneyInfo.js
+++ b/src/components/sidepanel/journeyDetails/JourneyInfo.js
@@ -39,9 +39,17 @@ const Line = styled.div`
   }
 `;
 
-export default ({journey, departure, date, originStopTimes}) => {
+export default ({
+  journey,
+  departure,
+  date,
+  originStopTimes,
+  destinationStopTimes,
+}) => {
   const equipment = <Equipment journey={journey} departure={departure} />;
   const equipmentType = getEquipmentType(departure.equipmentType);
+
+  console.log(originStopTimes.departure);
 
   return (
     <JourneyInfo>
@@ -50,14 +58,14 @@ export default ({journey, departure, date, originStopTimes}) => {
           <JourneyInfoRow>
             <Line>
               <span>Terminal time</span>
-              <span>{get(originStopTimes.departure, "terminalTime", 3)} min</span>
+              <span>{get(originStopTimes.departure, "terminalTime", 0)} min</span>
             </Line>
             <Line right>
               <CalculateTerminalTime
                 date={date}
                 departure={originStopTimes.departure}
                 event={originStopTimes.arrivalEvent}>
-                {({diffMinutes, diffSeconds, wasLate}) => (
+                {({diffMinutes, diffSeconds, wasLate, sign}) => (
                   <strong style={{color: wasLate ? "var(--red)" : "inherit"}}>
                     {doubleDigit(diffMinutes)}:{doubleDigit(diffSeconds)}
                   </strong>
@@ -68,7 +76,21 @@ export default ({journey, departure, date, originStopTimes}) => {
           <JourneyInfoRow>
             <Line>
               <span>Recovery time</span>
-              <span>{get(originStopTimes.departure, "recoveryTime", 3)} min</span>
+              <span>{get(originStopTimes.departure, "recoveryTime", 0)} min</span>
+            </Line>
+            <Line right>
+              <CalculateTerminalTime
+                recovery={true}
+                date={date}
+                departure={destinationStopTimes.departure}
+                event={destinationStopTimes.arrivalEvent}>
+                {({diffMinutes, diffSeconds, wasLate, sign}) => (
+                  <strong style={{color: wasLate ? "var(--red)" : "inherit"}}>
+                    {sign === "-" ? "-" : ""}
+                    {doubleDigit(diffMinutes)}:{doubleDigit(diffSeconds)}
+                  </strong>
+                )}
+              </CalculateTerminalTime>
             </Line>
           </JourneyInfoRow>
         </>

--- a/src/components/sidepanel/journeyDetails/JourneyInfo.js
+++ b/src/components/sidepanel/journeyDetails/JourneyInfo.js
@@ -101,7 +101,11 @@ export default ({
         <Line>
           <span>Equipment required</span>
           <span>
-            {equipmentType ? <>{equipmentType}</> : "No type"}
+            {equipmentType
+              ? equipmentType
+              : departure.equipmentType
+              ? departure.equipmentType
+              : "No type"}
             {departure.trunkColorRequired === 1 && <>, HSL-orans</>}
           </span>
         </Line>

--- a/src/components/sidepanel/journeyDetails/JourneyInfo.js
+++ b/src/components/sidepanel/journeyDetails/JourneyInfo.js
@@ -34,7 +34,7 @@ const Line = styled.div`
   justify-content: ${({right = false}) => (right ? "flex-end" : "space-between")};
   color: var(--dark-grey);
 
-  span:first-child {
+  > span:first-child {
     color: var(--grey);
   }
 `;

--- a/src/components/sidepanel/journeyDetails/equipmentType.js
+++ b/src/components/sidepanel/journeyDetails/equipmentType.js
@@ -17,22 +17,13 @@ const equipment = {
   "20": "A1",
   "21": "A1",
   "22": "A2",
-};
-
-const featureMap = {
-  "multi-axle": "C",
-  joint: "D",
-  high: "B",
-  short: "A1",
-  long: "A2",
+  R2: "R2",
+  R3: "R3",
+  R4: "R4",
 };
 
 export function getEquipmentType(code) {
-  return get(equipment, code + "", `code: ${code}`);
-}
-
-export function getFeature(type) {
-  return get(invert(featureMap), type, null);
+  return get(equipment, code + "", false);
 }
 
 export function checkRequirements(departure, equipment) {

--- a/src/components/sidepanel/journeyDetails/equipmentType.js
+++ b/src/components/sidepanel/journeyDetails/equipmentType.js
@@ -28,7 +28,7 @@ const featureMap = {
 };
 
 export function getEquipmentType(code) {
-  return get(equipment, code + "", null);
+  return get(equipment, code + "", `code: ${code}`);
 }
 
 export function getFeature(type) {
@@ -50,7 +50,7 @@ export function checkRequirements(departure, equipment) {
   const observedEquipment = {
     type: {
       observed: type,
-      required: equipmentRequired != 0 ? plannedEquipmentType : false,
+      required: equipmentRequired !== 0 ? plannedEquipmentType : false,
     },
     exteriorColor: {
       observed: exteriorColor,

--- a/src/components/sidepanel/journeyDetails/equipmentType.js
+++ b/src/components/sidepanel/journeyDetails/equipmentType.js
@@ -40,9 +40,6 @@ export function checkRequirements(departure, equipment) {
   const {type, exteriorColor} = equipment;
 
   const plannedEquipmentType = getEquipmentType(equipmentType);
-  const plannedFeature = getFeature(plannedEquipmentType);
-
-  const observedFeature = getFeature(type);
 
   // Map observed equipment features to planned ones. For each category, the observed
   // value goes in the "observed" prop and the "required" prop has the planned
@@ -53,15 +50,11 @@ export function checkRequirements(departure, equipment) {
   const observedEquipment = {
     type: {
       observed: type,
-      required: equipmentRequired ? plannedEquipmentType : false,
+      required: equipmentRequired != 0 ? plannedEquipmentType : false,
     },
     exteriorColor: {
       observed: exteriorColor,
       required: trunkColorRequired ? "HSL-orans" : false,
-    },
-    multiAxle: {
-      observed: observedFeature,
-      required: equipmentRequired ? plannedFeature : false,
     },
   };
 

--- a/src/helpers/getAdjustedDepartureDate.js
+++ b/src/helpers/getAdjustedDepartureDate.js
@@ -1,8 +1,8 @@
 import moment from "moment-timezone";
 import {combineDateAndTime} from "./time";
 import doubleDigit from "./doubleDigit";
-import get from "lodash/get";
 
+// Adjusts a 30-hour day time to it's equivalent 24-hour day time.
 export const getAdjustedDate = (hours, minutes, date) => {
   const adjustedDate =
     (hours === 4 && minutes < 30) || hours < 4
@@ -15,16 +15,10 @@ export const getAdjustedDate = (hours, minutes, date) => {
   return adjustedDate;
 };
 
-export const getAdjustedEventDate = (event) => {
-  const eventMoment = moment.tz(get(event, "receivedAt"), "Europe/Helsinki");
-  const hours = eventMoment.hour();
-  const minutes = eventMoment.minute();
-
-  return getAdjustedDate(hours, minutes, get(event, "oday"));
-};
-
 /**
- * Creates a moment from a departure time with 30-hour day adjustments applied.
+ * Creates a moment from a departure time. Departure times follow the 30-hour day
+ * schedule, so early morning times before 4:30 belong to the previous day.
+ * Moments always use 24 hour days so it will be adjusted to work correctly.
  *
  * @param departure
  * @param date

--- a/src/queries/DeparturesQuery.js
+++ b/src/queries/DeparturesQuery.js
@@ -39,6 +39,12 @@ const departuresQuery = gql`
         minutes
         arrivalHours
         arrivalMinutes
+        terminalTime
+        recoveryTime
+        equipmentRequired
+        equipmentType
+        trunkColorRequired
+        operatorId
         dateBegin
         dateEnd
         routeId

--- a/src/queries/HfpQuery.js
+++ b/src/queries/HfpQuery.js
@@ -42,7 +42,7 @@ export const queryHfp = async (route, date, time) => {
   const {routeId, direction} = route;
   const fetchedJourneyId = getJourneyId(createCompositeJourney(date, route, time));
 
-  const client = await getClient();
+  const client = getClient();
 
   const {data} = await client.query({
     query: hfpQuery,

--- a/src/queries/HfpQuery.js
+++ b/src/queries/HfpQuery.js
@@ -5,8 +5,6 @@ import HfpFieldsFragment from "./HfpFieldsFragment";
 import getJourneyId from "../helpers/getJourneyId";
 import {combineDateAndTime} from "../helpers/time";
 
-const client = getClient();
-
 function createCompositeJourney(date, route, time) {
   if (!route || !route.routeId || !date || !time) {
     return false;
@@ -40,19 +38,21 @@ export const hfpQuery = gql`
   ${HfpFieldsFragment}
 `;
 
-export const queryHfp = (route, date, time) => {
+export const queryHfp = async (route, date, time) => {
   const {routeId, direction} = route;
   const fetchedJourneyId = getJourneyId(createCompositeJourney(date, route, time));
 
-  return client
-    .query({
-      query: hfpQuery,
-      variables: {
-        route_id: routeId,
-        direction: parseInt(direction, 10),
-        date,
-        time,
-      },
-    })
-    .then(({data}) => ({data: get(data, "vehicles", []), fetchedJourneyId}));
+  const client = await getClient();
+
+  const {data} = await client.query({
+    query: hfpQuery,
+    variables: {
+      route_id: routeId,
+      direction: parseInt(direction, 10),
+      date,
+      time,
+    },
+  });
+
+  return {data: get(data, "vehicles", []), fetchedJourneyId};
 };

--- a/src/queries/RouteFieldsFragment.js
+++ b/src/queries/RouteFieldsFragment.js
@@ -52,9 +52,12 @@ export const ExtensiveRouteFieldsFragment = gql`
           dateBegin
           dateEnd
           dayType
+          terminalTime
+          recoveryTime
           equipmentRequired
           equipmentType
           trunkColorRequired
+          operatorId
         }
       }
     }
@@ -83,9 +86,12 @@ export const ExtensiveRouteFieldsFragment = gql`
           dateBegin
           dateEnd
           dayType
+          terminalTime
+          recoveryTime
           equipmentRequired
           equipmentType
           trunkColorRequired
+          operatorId
         }
       }
     }
@@ -123,9 +129,12 @@ export const ExtensiveRouteFieldsFragment = gql`
               dateBegin
               dateEnd
               dayType
+              terminalTime
+              recoveryTime
               equipmentRequired
               equipmentType
               trunkColorRequired
+              operatorId
             }
           }
         }


### PR DESCRIPTION
Fixes various issues with the journey sidebar data.

- Mark the origin stop arrival time as calculated from the terminal time
- Calculate the realized recovery time
- Only show arrival times at the destination stop
- Fix issue where the observed vehicle is not found
- Had to re-arrange the cache persistence since I was getting errors. Need to add a button to clear the cache.