### PR TITLE
Fix stop grouping

### DIFF
--- a/src/components/map/StopLayer.js
+++ b/src/components/map/StopLayer.js
@@ -37,7 +37,7 @@ class StopLayer extends Component {
             }
 
             if (!bounds) {
-              bounds = pos.toBounds(40);
+              bounds = pos.toBounds(3);
             }
 
             const stopGroup = groups.get(bounds) || [];

--- a/src/helpers/vehicleColor.js
+++ b/src/helpers/vehicleColor.js
@@ -27,7 +27,3 @@ export function getPriorityMode(modes) {
 
   return modes[0];
 }
-
-export function createColor() {
-  return `rgb(${random(0, 150)}, ${random(0, 150)}, ${random(0, 150)})`;
-}


### PR DESCRIPTION
Fixes #168 . Groups stops that are within 3 meters of each other, which also catches stops that would otherwise be barely visible under the other markers even on very close zoom levels.

Branch based on master.