### PR TITLE
Doubled journeys

### DIFF
--- a/src/components/JourneyPosition.js
+++ b/src/components/JourneyPosition.js
@@ -114,14 +114,17 @@ class JourneyPosition extends Component {
     );
   }
 
-  componentDidUpdate() {
+  componentDidUpdate({positions: prevPositions}) {
     const {
       positions = [],
       state: {unixTime},
     } = this.props;
 
     // If the positions changed we need to index again.
-    if (!this.isLive && positions.length !== 0) {
+    if (
+      !this.isLive &&
+      (positions !== prevPositions || positions.length !== prevPositions.length)
+    ) {
       this.indexJourneys(positions);
       this.getHfpPositions(unixTime);
     }

--- a/src/components/RouteJourneys.js
+++ b/src/components/RouteJourneys.js
@@ -47,7 +47,7 @@ class RouteJourneys extends React.Component {
                         date,
                         departure,
                         timeStr,
-                        1
+                        0
                       );
 
                       // A theoretically-valid journey id can be derived from the departure data

--- a/src/components/RouteJourneys.js
+++ b/src/components/RouteJourneys.js
@@ -74,10 +74,13 @@ class RouteJourneys extends React.Component {
 
                 // Map HFP journeys to the departures through the journey id.
                 const departureJourneys = sortedJourneys.map((plannedJourney) => {
-                  const journey = get(journeys, plannedJourney.journeyId, null);
+                  const journeyEvents = get(journeys, plannedJourney.journeyId, []);
                   return {
                     ...plannedJourney,
-                    events: !journey ? journeyHfpStates.NOT_FOUND : [journey],
+                    events:
+                      journeyEvents.length === 0
+                        ? journeyHfpStates.NOT_FOUND
+                        : journeyEvents,
                   };
                 });
 

--- a/src/components/RouteJourneys.js
+++ b/src/components/RouteJourneys.js
@@ -46,7 +46,8 @@ class RouteJourneys extends React.Component {
                       const departureJourney = createCompositeJourney(
                         date,
                         departure,
-                        timeStr
+                        timeStr,
+                        1
                       );
 
                       // A theoretically-valid journey id can be derived from the departure data

--- a/src/components/SelectedJourneyEvents.js
+++ b/src/components/SelectedJourneyEvents.js
@@ -31,6 +31,8 @@ class SelectedJourneyEvents extends Component {
       parseInt(get(route, "direction", 0), 10) ===
         parseInt(selectedJourney.direction_id, 10);
 
+    console.log(selectedJourney);
+
     return (
       <SelectedJourneyQuery
         skip={!selectedJourneyValid}
@@ -52,9 +54,10 @@ class SelectedJourneyEvents extends Component {
           // on which side of the 24h+ day the journey happened.
           const realStartMoment = moment.tz(positions[0].tst, TIMEZONE);
 
-          const events = filteredEvents.map((item) =>
-            createHfpItem(item, realStartMoment)
-          );
+          const events = filteredEvents.map((item) => {
+            item.instance = selectedJourney.instance || 0;
+            return createHfpItem(item, realStartMoment);
+          });
 
           const journeyId = getJourneyId(events[0]);
 

--- a/src/components/SelectedJourneyEvents.js
+++ b/src/components/SelectedJourneyEvents.js
@@ -31,8 +31,6 @@ class SelectedJourneyEvents extends Component {
       parseInt(get(route, "direction", 0), 10) ===
         parseInt(selectedJourney.direction_id, 10);
 
-    console.log(selectedJourney);
-
     return (
       <SelectedJourneyQuery
         skip={!selectedJourneyValid}

--- a/src/components/filterbar/VehicleSettings.js
+++ b/src/components/filterbar/VehicleSettings.js
@@ -41,7 +41,13 @@ class VehicleSettings extends React.Component {
 
   render() {
     const {state} = this.props;
-    const {vehicle = "", date} = state;
+    const {vehicle = "", date, selectedJourney} = state;
+
+    const isDisabled = !!selectedJourney;
+
+    if (isDisabled) {
+      return this.renderInput(undefined, vehicle, true);
+    }
 
     return (
       <>

--- a/src/components/filterbar/VehicleSettings.js
+++ b/src/components/filterbar/VehicleSettings.js
@@ -41,13 +41,7 @@ class VehicleSettings extends React.Component {
 
   render() {
     const {state} = this.props;
-    const {vehicle = "", date, selectedJourney} = state;
-
-    const isDisabled = !!selectedJourney;
-
-    if (isDisabled) {
-      return this.renderInput(undefined, vehicle, true);
-    }
+    const {vehicle = "", date} = state;
 
     return (
       <>

--- a/src/components/map/MapContent.js
+++ b/src/components/map/MapContent.js
@@ -40,7 +40,7 @@ class MapContent extends Component {
       setMapBounds,
       viewLocation,
       queryBounds,
-      state: {vehicle, selectedJourney, date, mapOverlays, areaEventsStyle},
+      state: {selectedJourney, date, mapOverlays, areaEventsStyle},
     } = this.props;
 
     const hasRoute = !!route && !!route.routeId;
@@ -120,8 +120,10 @@ class MapContent extends Component {
             {journeys.length !== 0 &&
               journeys.map(({events: journeyPositions, journeyId}) => {
                 if (
-                  vehicle &&
-                  get(journeyPositions, "[0].unique_vehicle_id", "") !== vehicle
+                  selectedJourney &&
+                  selectedJourney.unique_vehicle_id &&
+                  get(journeyPositions, "[0].unique_vehicle_id", "") !==
+                    selectedJourney.unique_vehicle_id
                 ) {
                   return null;
                 }

--- a/src/components/sidepanel/TimetableDeparture.js
+++ b/src/components/sidepanel/TimetableDeparture.js
@@ -113,7 +113,9 @@ class TimetableDeparture extends Component {
     const journeyIsSelected =
       !!selectedJourneyId &&
       selectedJourneyId ===
-        getJourneyId(createCompositeJourney(date, departure, originDepartureTime));
+        getJourneyId(
+          createCompositeJourney(date, departure, originDepartureTime, 0)
+        );
 
     const renderListRow = this.renderListRow(
       journeyIsSelected,

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -236,7 +236,7 @@ class TimetablePanel extends Component {
           return (
             selectedJourneyId ===
             getJourneyId(
-              createCompositeJourney(date, departure, originDepartureTime)
+              createCompositeJourney(date, departure, originDepartureTime, 0)
             )
           );
         })

--- a/src/components/sidepanel/VehicleJourneys.js
+++ b/src/components/sidepanel/VehicleJourneys.js
@@ -146,7 +146,8 @@ class VehicleJourneys extends Component {
     if (
       nextSelectedJourney &&
       ((selectedJourney &&
-        getJourneyId(nextSelectedJourney) !== getJourneyId(selectedJourney)) ||
+        getJourneyId(nextSelectedJourney, false) !==
+          getJourneyId(selectedJourney, false)) ||
         !selectedJourney)
     ) {
       this.selectJourney(nextSelectedJourney);
@@ -160,7 +161,7 @@ class VehicleJourneys extends Component {
       state: {selectedJourney, date, vehicle},
     } = this.props;
 
-    const selectedJourneyId = getJourneyId(selectedJourney);
+    const selectedJourneyId = getJourneyId(selectedJourney, false);
     // Keep track of the journey index independent of vehicle groups
     let journeyIndex = -1;
 
@@ -195,7 +196,7 @@ class VehicleJourneys extends Component {
         {(scrollRef) =>
           sortedPositions.map((journey) => {
             journeyIndex++;
-            const journeyId = getJourneyId(journey);
+            const journeyId = getJourneyId(journey, false);
 
             const mode = get(journey, "mode", "").toUpperCase();
             const journeyTime = get(journey, "journey_start_time", "");

--- a/src/helpers/EnsureJourneySelection.js
+++ b/src/helpers/EnsureJourneySelection.js
@@ -21,7 +21,9 @@ class EnsureJourneySelection extends Component {
     if ((!events || events.length === 0) && !eventsLoading) {
       Journey.setSelectedJourney(null);
     } else if (events && !eventsLoading) {
-      Filters.setVehicle(get(events, "[0].events[0].unique_vehicle_id", ""));
+      const vehicleId = get(events, "[0].events[0].unique_vehicle_id", "");
+      Filters.setVehicle(vehicleId);
+      Journey.setJourneyVehicle(vehicleId);
     }
   }
 

--- a/src/helpers/getJourneyId.js
+++ b/src/helpers/getJourneyId.js
@@ -1,7 +1,7 @@
 import {pickJourneyProps} from "./pickJourneyProps";
 
-const getJourneyId = (journey = null) => {
-  const {
+const getJourneyId = (journey = null, matchInstance = true) => {
+  let {
     oday = null,
     journey_start_time = null,
     route_id = null,
@@ -10,6 +10,10 @@ const getJourneyId = (journey = null) => {
   } = pickJourneyProps(journey || {});
 
   if (!route_id || !oday || !journey_start_time) return "";
+
+  if (!matchInstance) {
+    instance = 0;
+  }
 
   return `journey:${oday}_${journey_start_time}_${route_id}_${direction_id}_${instance}`;
 };

--- a/src/helpers/getJourneyId.js
+++ b/src/helpers/getJourneyId.js
@@ -1,14 +1,17 @@
 import {pickJourneyProps} from "./pickJourneyProps";
 
-export default (journey = null) => {
+const getJourneyId = (journey = null) => {
   const {
     oday = null,
     journey_start_time = null,
     route_id = null,
     direction_id = null,
+    instance = 1,
   } = pickJourneyProps(journey || {});
 
   if (!route_id || !oday || !journey_start_time) return "";
 
-  return `journey:${oday}_${journey_start_time}_${route_id}_${direction_id}`;
+  return `journey:${oday}_${journey_start_time}_${route_id}_${direction_id}_${instance}`;
 };
+
+export default getJourneyId;

--- a/src/helpers/getJourneyId.js
+++ b/src/helpers/getJourneyId.js
@@ -6,7 +6,7 @@ const getJourneyId = (journey = null) => {
     journey_start_time = null,
     route_id = null,
     direction_id = null,
-    instance = 1,
+    instance = 0,
   } = pickJourneyProps(journey || {});
 
   if (!route_id || !oday || !journey_start_time) return "";

--- a/src/helpers/getJourneyId.test.js
+++ b/src/helpers/getJourneyId.test.js
@@ -6,17 +6,17 @@ describe("getJourneyId", () => {
     journey_start_time: "starttime",
     route_id: "routeid",
     direction_id: "direction",
-    instance: 1,
+    instance: 0,
   };
 
   test("Returns a string that uniquely identifies the journey.", () => {
     const journeyId = getJourneyId(journey);
-    expect(journeyId).toBe("journey:date_starttime_routeid_direction_1");
+    expect(journeyId).toBe("journey:date_starttime_routeid_direction_0");
   });
 
   test("Only cares about relevant props.", () => {
     const modifiedJourney = {...journey, irrelevantProp: "irrelevant value"};
     const journeyId = getJourneyId(modifiedJourney);
-    expect(journeyId).toBe("journey:date_starttime_routeid_direction_1");
+    expect(journeyId).toBe("journey:date_starttime_routeid_direction_0");
   });
 });

--- a/src/helpers/getJourneyId.test.js
+++ b/src/helpers/getJourneyId.test.js
@@ -6,16 +6,17 @@ describe("getJourneyId", () => {
     journey_start_time: "starttime",
     route_id: "routeid",
     direction_id: "direction",
+    instance: 1,
   };
 
   test("Returns a string that uniquely identifies the journey.", () => {
     const journeyId = getJourneyId(journey);
-    expect(journeyId).toBe("journey:date_starttime_routeid_direction");
+    expect(journeyId).toBe("journey:date_starttime_routeid_direction_1");
   });
 
   test("Only cares about relevant props.", () => {
     const modifiedJourney = {...journey, irrelevantProp: "irrelevant value"};
     const journeyId = getJourneyId(modifiedJourney);
-    expect(journeyId).toBe("journey:date_starttime_routeid_direction");
+    expect(journeyId).toBe("journey:date_starttime_routeid_direction_1");
   });
 });

--- a/src/helpers/pickJourneyProps.js
+++ b/src/helpers/pickJourneyProps.js
@@ -2,7 +2,7 @@ import pick from "lodash/pick";
 
 export function pickJourneyProps(hfp) {
   return pick(
-    {instance: 1, unique_vehicle_id: "unknown-vehicle", ...hfp},
+    {instance: 0, unique_vehicle_id: "unknown-vehicle", ...hfp},
     "oday",
     "journey_start_time",
     "direction_id",

--- a/src/helpers/pickJourneyProps.js
+++ b/src/helpers/pickJourneyProps.js
@@ -1,5 +1,13 @@
 import pick from "lodash/pick";
 
 export function pickJourneyProps(hfp) {
-  return pick(hfp, "oday", "journey_start_time", "direction_id", "route_id");
+  return pick(
+    {instance: 1, unique_vehicle_id: "unknown-vehicle", ...hfp},
+    "oday",
+    "journey_start_time",
+    "direction_id",
+    "route_id",
+    "instance",
+    "unique_vehicle_id"
+  );
 }

--- a/src/queries/JourneysByDateQuery.js
+++ b/src/queries/JourneysByDateQuery.js
@@ -91,7 +91,18 @@ class JourneysByDateQuery extends React.Component {
           const journeyItems = vehicles.reduce((journeys, rawEvent) => {
             const event = createHfpItem(rawEvent);
             const journeyId = getJourneyId(event);
-            journeys[journeyId] = event;
+            const journeyEvents = journeys[journeyId];
+
+            if (
+              typeof journeyEvents !== "undefined" &&
+              Array.isArray(journeyEvents)
+            ) {
+              event.instance = 1;
+              journeyEvents.push(event);
+            } else {
+              journeys[journeyId] = [event];
+            }
+
             return journeys;
           }, {});
 

--- a/src/queries/JourneysByDateQuery.js
+++ b/src/queries/JourneysByDateQuery.js
@@ -15,8 +15,8 @@ export const journeysByDateQuery = gql`
     $stopId: String
   ) {
     vehicles(
-      distinct_on: journey_start_time
-      order_by: [{journey_start_time: asc}, {tst: desc}]
+      distinct_on: [journey_start_time, unique_vehicle_id]
+      order_by: [{journey_start_time: asc}, {unique_vehicle_id: asc}, {tst: desc}]
       where: {
         oday: {_eq: $date}
         route_id: {_eq: $route_id}

--- a/src/queries/SelectedJourneyQuery.js
+++ b/src/queries/SelectedJourneyQuery.js
@@ -1,5 +1,6 @@
 import React from "react";
 import get from "lodash/get";
+import pick from "lodash/pick";
 import gql from "graphql-tag";
 import HfpFieldsFragment from "./HfpFieldsFragment";
 import {observer, inject} from "mobx-react";
@@ -62,7 +63,13 @@ class SelectedJourneyQuery extends React.Component {
     const isNextDay = normalStartTime !== journeyStartTime;
 
     const queryVars = {
-      ...selectedJourney,
+      ...pick(
+        selectedJourney,
+        "route_id",
+        "direction_id",
+        "journey_start_time",
+        "oday"
+      ),
       journey_start_time: normalStartTime,
       compareReceivedAt: isNextDay
         ? {

--- a/src/queries/SelectedJourneyQuery.js
+++ b/src/queries/SelectedJourneyQuery.js
@@ -14,9 +14,10 @@ import {TIMEZONE} from "../constants";
 export const hfpQuery = gql`
   query selectedJourneyQuery(
     $oday: date!
-    $route_id: String
-    $journey_start_time: time
-    $direction_id: smallint
+    $route_id: String!
+    $journey_start_time: time!
+    $direction_id: smallint!
+    $unique_vehicle_id: String
     $compareReceivedAt: timestamptz_comparison_exp
   ) {
     vehicles(
@@ -26,6 +27,7 @@ export const hfpQuery = gql`
         route_id: {_eq: $route_id}
         direction_id: {_eq: $direction_id}
         journey_start_time: {_eq: $journey_start_time}
+        unique_vehicle_id: {_eq: $unique_vehicle_id}
         tst: $compareReceivedAt
       }
     ) {
@@ -68,7 +70,8 @@ class SelectedJourneyQuery extends React.Component {
         "route_id",
         "direction_id",
         "journey_start_time",
-        "oday"
+        "oday",
+        "unique_vehicle_id"
       ),
       journey_start_time: normalStartTime,
       compareReceivedAt: isNextDay

--- a/src/queries/SelectedJourneyQuery.js
+++ b/src/queries/SelectedJourneyQuery.js
@@ -1,6 +1,7 @@
 import React from "react";
 import get from "lodash/get";
 import pick from "lodash/pick";
+import groupBy from "lodash/groupBy";
 import gql from "graphql-tag";
 import HfpFieldsFragment from "./HfpFieldsFragment";
 import {observer, inject} from "mobx-react";
@@ -70,9 +71,9 @@ class SelectedJourneyQuery extends React.Component {
         "route_id",
         "direction_id",
         "journey_start_time",
-        "oday",
-        "unique_vehicle_id"
+        "oday"
       ),
+      unique_vehicle_id: selectedJourney.unique_vehicle_id || undefined,
       journey_start_time: normalStartTime,
       compareReceivedAt: isNextDay
         ? {
@@ -94,7 +95,25 @@ class SelectedJourneyQuery extends React.Component {
 
           setUpdateListener(updateListenerName, this.onUpdate(refetch));
 
-          const vehicles = get(data, "vehicles", []);
+          let vehicles = get(data, "vehicles", []);
+
+          // If there is multiple instances of the journey and the selected journey
+          // was not fetched with a vehicle ID, get the relevant journey
+          // instance from the result.
+          if (
+            selectedJourney &&
+            selectedJourney.instance &&
+            !selectedJourney.unique_vehicle_id
+          ) {
+            const vehicleGroups = Object.values(
+              groupBy(vehicles, "unique_vehicle_id")
+            );
+
+            if (vehicleGroups.length > 1) {
+              vehicles = vehicleGroups[selectedJourney.instance];
+            }
+          }
+
           return children({positions: vehicles, loading, error});
         }}
       </Query>

--- a/src/queries/SelectedJourneyQuery.js
+++ b/src/queries/SelectedJourneyQuery.js
@@ -73,7 +73,7 @@ class SelectedJourneyQuery extends React.Component {
         "journey_start_time",
         "oday"
       ),
-      unique_vehicle_id: selectedJourney.unique_vehicle_id || undefined,
+      unique_vehicle_id: get(selectedJourney, "unique_vehicle_id") || undefined,
       journey_start_time: normalStartTime,
       compareReceivedAt: isNextDay
         ? {

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -38,6 +38,7 @@ export default (state) => {
 
       let dateStr = "";
       let timeStr = "";
+      const vehicleId = getUrlValue("vehicle", "");
 
       if (date.isValid()) {
         dateStr = date.format("YYYY-MM-DD");
@@ -68,6 +69,7 @@ export default (state) => {
           direction_id,
           journey_start_time: timeStr,
           instance: instance ? parseInt(instance, 10) : 0,
+          unique_vehicle_id: vehicleId,
         });
 
         if (getJourneyId(state.selectedJourney) !== getJourneyId(journey)) {

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -30,7 +30,7 @@ export default (state) => {
       journey_start_time,
       route_id,
       direction_id,
-      instance = 1,
+      instance = 0,
     ] = pathname.split("/");
 
     if (basePath === "journey") {
@@ -67,7 +67,7 @@ export default (state) => {
           route_id,
           direction_id,
           journey_start_time: timeStr,
-          instance: instance ? parseInt(instance, 10) : 1,
+          instance: instance ? parseInt(instance, 10) : 0,
         });
 
         if (getJourneyId(state.selectedJourney) !== getJourneyId(journey)) {

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -30,6 +30,7 @@ export default (state) => {
       journey_start_time,
       route_id,
       direction_id,
+      instance = 1,
     ] = pathname.split("/");
 
     if (basePath === "journey") {
@@ -66,6 +67,7 @@ export default (state) => {
           route_id,
           direction_id,
           journey_start_time: timeStr,
+          instance: instance ? parseInt(instance, 10) : 1,
         });
 
         if (getJourneyId(state.selectedJourney) !== getJourneyId(journey)) {

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -47,6 +47,11 @@ export default (state) => {
         setPathName("/");
       } else if (hfpItem) {
         state.selectedJourney = pickJourneyProps(hfpItem);
+
+        if (hfpItem.unique_vehicle_id) {
+          filters.setVehicle(hfpItem.unique_vehicle_id);
+        }
+
         setPathName(createJourneyPath(hfpItem));
       }
     }

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -8,14 +8,14 @@ import get from "lodash/get";
 export function createJourneyPath(journey) {
   const dateStr = journey.oday.replace(/-/g, "");
   const timeStr = journey.journey_start_time.replace(/:/g, "");
-  const instance = get(journey, "instance", 1);
+  const instance = get(journey, "instance", 0);
 
   return `/journey/${dateStr}/${timeStr}/${journey.route_id}/${
     journey.direction_id
   }/${instance}`;
 }
 
-export function createCompositeJourney(date, route, time, instance = 1) {
+export function createCompositeJourney(date, route, time, instance = 0) {
   if (!route || !route.routeId || !date || !time) {
     return false;
   }
@@ -25,7 +25,7 @@ export function createCompositeJourney(date, route, time, instance = 1) {
     journey_start_time: time,
     route_id: route.routeId,
     direction_id: route.direction,
-    instance: instance || 1,
+    instance: instance || 0,
   };
 
   return journey;

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -3,17 +3,19 @@ import getJourneyId from "../helpers/getJourneyId";
 import {pickJourneyProps} from "../helpers/pickJourneyProps";
 import filterActions from "./filterActions";
 import {setPathName} from "./UrlManager";
+import get from "lodash/get";
 
 export function createJourneyPath(journey) {
   const dateStr = journey.oday.replace(/-/g, "");
   const timeStr = journey.journey_start_time.replace(/:/g, "");
+  const instance = get(journey, "instance", 1);
 
   return `/journey/${dateStr}/${timeStr}/${journey.route_id}/${
     journey.direction_id
-  }`;
+  }/${instance}`;
 }
 
-export function createCompositeJourney(date, route, time) {
+export function createCompositeJourney(date, route, time, instance = 1) {
   if (!route || !route.routeId || !date || !time) {
     return false;
   }
@@ -23,6 +25,7 @@ export function createCompositeJourney(date, route, time) {
     journey_start_time: time,
     route_id: route.routeId,
     direction_id: route.direction,
+    instance: instance || 1,
   };
 
   return journey;
@@ -30,14 +33,6 @@ export function createCompositeJourney(date, route, time) {
 
 export default (state) => {
   const filters = filterActions(state);
-
-  // Sets the resolved state of a fetched journey.
-  const setJourneyFetchState = action(
-    "Set the status of a requested journey",
-    (journeyId, resolveState) => {
-      state.resolvedJourneyStates.set(journeyId, resolveState);
-    }
-  );
 
   const setSelectedJourney = action(
     "Set selected journey",
@@ -51,21 +46,28 @@ export default (state) => {
         filters.setVehicle(null);
         setPathName("/");
       } else if (hfpItem) {
-        const journey = pickJourneyProps(hfpItem);
-        state.selectedJourney = journey;
-
-        if (hfpItem.unique_vehicle_id) {
-          filters.setVehicle(hfpItem.unique_vehicle_id);
-        }
-
+        state.selectedJourney = pickJourneyProps(hfpItem);
         setPathName(createJourneyPath(hfpItem));
       }
     }
   );
 
+  const setJourneyVehicle = action((vehicleId) => {
+    const {selectedJourney} = state;
+
+    if (
+      vehicleId &&
+      selectedJourney &&
+      (!selectedJourney.unique_vehicle_id ||
+        selectedJourney.unique_vehicle_id === "unknown-vehicle")
+    ) {
+      selectedJourney.unique_vehicle_id = vehicleId;
+    }
+  });
+
   return {
     setSelectedJourney,
-    setJourneyFetchState,
+    setJourneyVehicle,
     createCompositeJourney,
   };
 };


### PR DESCRIPTION
Fixes #201 well enough. Only the "Journeys" tab is fully compatible with doubled journeys.

The Vehicle journeys ("lähtöketju") tab will display the second vehicle as selected when it is, but if you select another journey of the same vehicle the "doubled" status will be lost, and going back to the "Journeys" tab with the second vehicle of the journey selected, it will show the first one as selected.

The timetables tab will always show times from the second journey. This can probably be fixed fairly easily but let's get feedback from the team first.

Test link: http://localhost:3000/journey/20190215/072800/4573/1/0?mapView=60.29310778895614%2C24.905748367309574%2C13&line.lineId=4573&route.routeId=4573&route.direction=1&vehicle=36%2F11&time=07%3A28%3A00&tab=journeys&date=2019-02-15