### PR TITLE
Fix vehicle search

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -62,10 +62,8 @@ export const getClient = async (UIStore) => {
 
   const cache = new InMemoryCache();
 
-  const joreLink = new BatchHttpLink({
+  const joreLink = new HttpLink({
     uri: joreUrl,
-    batchMax: 10,
-    batchInterval: 10,
   });
 
   const hfpLink = concat(
@@ -76,10 +74,12 @@ export const getClient = async (UIStore) => {
   );
 
   // Split the operation between the JORE api and the HFP api depending on the query.
+  // Since the HFP api only has one query we can just check if we're fetching that.
   const splitLink = split(
     (operation) => {
       const queryName = get(
         operation,
+        // Need to dig a little deeper for unnamed queries
         "query.definitions[0].selectionSet.selections[0].name.value",
         "none"
       );

--- a/src/components/filterbar/SuggestionInput.js
+++ b/src/components/filterbar/SuggestionInput.js
@@ -86,7 +86,7 @@ class SuggestionInput extends Component {
 
   onSuggestionsFetchRequested = ({value}) => {
     const {getSuggestions} = this.props;
-    this.setSuggestions(getSuggestions(value));
+    this.setSuggestions(getSuggestions(value) || []);
   };
 
   onSuggestionsClearRequested = () => {

--- a/src/components/filterbar/VehicleInput.js
+++ b/src/components/filterbar/VehicleInput.js
@@ -58,7 +58,7 @@ function escapeRegexCharacters(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-const getSuggestions = (operators) => (value = "") => {
+const matchSuggestions = (operators, value = "") => {
   const inputValue = escapeRegexCharacters(value.trim().toLowerCase());
   const inputWords = words(inputValue, /[^\s]+/g).filter((w) => !!w);
 
@@ -87,6 +87,8 @@ const getSuggestions = (operators) => (value = "") => {
         })
         .filter((operator) => operator.vehicles.length > 0);
 };
+
+const getSuggestions = (operators) => (value) => matchSuggestions(operators, value);
 
 const enhance = flow(
   observer,

--- a/src/components/filterbar/VehicleInput.js
+++ b/src/components/filterbar/VehicleInput.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useMemo} from "react";
 import SuggestionInput, {
   SuggestionContent,
   SuggestionText,
@@ -36,7 +36,10 @@ const renderSuggestion = (suggestion, {query, isHighlighted}) => {
   return (
     <VehicleSuggestion
       isHighlighted={isHighlighted}
-      inService={!!suggestion.inServiceOnDate}>
+      inService={
+        typeof suggestion.inServiceOnDate === "undefined" ||
+        suggestion.inServiceOnDate === true
+      }>
       <SuggestionText>{uniqueVehicleId}</SuggestionText>
     </VehicleSuggestion>
   );
@@ -49,23 +52,6 @@ const renderSectionTitle = (section) => (
 );
 
 const getSectionSuggestions = (section) => section.vehicles;
-
-function matchVehicleTerms(vehicles, term) {
-  let matches = [];
-
-  // Search operator vehicles and return the matching ones.
-  const matchingVehicles = vehicles.filter((vehicle) =>
-    (vehicle.vehicleId + vehicle.operatorId + vehicle.registryNr)
-      .toLowerCase()
-      .includes(term)
-  );
-
-  if (matchingVehicles.length !== 0) {
-    matches = matchingVehicles;
-  }
-
-  return matches;
-}
 
 function escapeRegexCharacters(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -107,6 +93,8 @@ const enhance = flow(
 );
 
 export default enhance(({value = "", onSelect, options = []}) => {
+  const suggestions = useMemo(() => getSuggestions(options), [options]);
+
   return (
     <SuggestionInput
       minimumInput={0}
@@ -117,7 +105,7 @@ export default enhance(({value = "", onSelect, options = []}) => {
       getSectionSuggestions={getSectionSuggestions}
       getValue={getSuggestionValue}
       renderSuggestion={renderSuggestion}
-      getSuggestions={getSuggestions(options)}
+      getSuggestions={suggestions}
     />
   );
 });

--- a/src/components/filterbar/VehicleInput.js
+++ b/src/components/filterbar/VehicleInput.js
@@ -6,6 +6,7 @@ import SuggestionInput, {
 } from "./SuggestionInput";
 import flow from "lodash/flow";
 import get from "lodash/get";
+import words from "lodash/words";
 import {observer} from "mobx-react-lite";
 import styled from "styled-components";
 import {inject} from "../../helpers/inject";
@@ -58,10 +59,8 @@ function escapeRegexCharacters(str) {
 }
 
 const getSuggestions = (operators) => (value = "") => {
-  const inputValue = value.trim().toLowerCase();
-  const inputWords = (inputValue.match(/\w+/g) || [""])
-    .map(escapeRegexCharacters)
-    .filter((w) => !!w);
+  const inputValue = escapeRegexCharacters(value.trim().toLowerCase());
+  const inputWords = words(inputValue, /[^\s]+/g).filter((w) => !!w);
 
   if (inputWords.length === 0) {
     return operators;
@@ -75,7 +74,9 @@ const getSuggestions = (operators) => (value = "") => {
             operatorName,
             operatorId,
             vehicles: vehicles.filter(({registryNr, vehicleId}) => {
-              const testStr = `${operatorName} ${operatorId} ${registryNr} ${vehicleId}`;
+              const testStr = `${operatorName} ${operatorId} ${vehicleId} ${registryNr} ${operatorId}/${vehicleId}`
+                .trim()
+                .toLowerCase();
 
               return inputWords.every((inputWord) => {
                 const regex = new RegExp(inputWord, "gi");

--- a/src/components/sidepanel/SidePanel.js
+++ b/src/components/sidepanel/SidePanel.js
@@ -104,6 +104,7 @@ class SidePanel extends Component {
         date,
         vehicle,
         stop: stateStop,
+        selectedJourney,
         sidePanelVisible,
         journeyDetailsAreOpen,
         journeyDetailsCanOpen,
@@ -118,8 +119,9 @@ class SidePanel extends Component {
     let suggestedTab = "";
 
     if (!hasRoute && !vehicle) suggestedTab = "area-journeys";
-    if (!hasRoute && vehicle) suggestedTab = "vehicle-journeys";
     if (hasRoute) suggestedTab = "journeys";
+    if (vehicle) suggestedTab = "vehicle-journeys";
+    if (selectedJourney) suggestedTab = "journeys";
     if (stateStop) suggestedTab = "timetables";
 
     const allTabsHidden =

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -34,6 +34,8 @@ export function createCompositeJourney(date, route, time, instance = 0) {
 export default (state) => {
   const filters = filterActions(state);
 
+  let prevVehicle = null;
+
   const setSelectedJourney = action(
     "Set selected journey",
     (hfpItem = null, toggle = true) => {
@@ -43,12 +45,14 @@ export default (state) => {
           getJourneyId(state.selectedJourney) === getJourneyId(hfpItem))
       ) {
         state.selectedJourney = null;
-        filters.setVehicle(null);
+        filters.setVehicle(prevVehicle);
         setPathName("/");
       } else if (hfpItem) {
         state.selectedJourney = pickJourneyProps(hfpItem);
 
         if (hfpItem.unique_vehicle_id) {
+          // Remember the previous selection so that we can set it back when deselecting the journey.
+          prevVehicle = state.vehicle || null;
           filters.setVehicle(hfpItem.unique_vehicle_id);
         }
 


### PR DESCRIPTION
Fixes various issues with the vehicle search.

- Make the search term matching stricter so that all term words have to match.
- Update the filtering logic
- Attempt to fix vehicles that shouldn't have events for the date having events (it seems to have worked). Fixes #221.
- Readjust the tab priorities to select the vehicle journeys tab when a vehicle is selected. Fixes #222.
- If there was a vehicle selection before selecting a journey, the selection will be restored in some cases when deselecting the journey. Not sure if this is the right move but let's see.
- Remove the batched link from JORE requests. Should speed up some faster queries that have had to wait for slower ones to finish, at the expense of making more queries.