### PR TITLE
Fixes and updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "resolve": "^1.9.0",
     "sass-loader": "^7.1.0",
     "serve": "^10.1.1",
+    "snifferjs": "^3.1.1",
     "style-loader": "^0.23.1",
     "styled-components": "^4.1.3",
     "styled-react-modal": "^1.2.1",

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,5 @@
 import {ApolloClient} from "apollo-client";
 import {concat, split, ApolloLink} from "apollo-link";
-import {BatchHttpLink} from "apollo-link-batch-http";
 import {HttpLink} from "apollo-link-http";
 import {InMemoryCache} from "apollo-cache-inmemory";
 import {onError} from "apollo-link-error";

--- a/src/components/Forms.js
+++ b/src/components/Forms.js
@@ -1,8 +1,6 @@
 import styled, {css, createGlobalStyle} from "styled-components";
 import React from "react";
-import Tooltip from "./Tooltip";
 import {useTooltip} from "../hooks/useTooltip";
-import {observer} from "mobx-react-lite";
 
 export const GlobalFormStyle = createGlobalStyle`
   select,

--- a/src/components/Forms.js
+++ b/src/components/Forms.js
@@ -50,6 +50,11 @@ export const InputStyles = css`
   &:focus {
     border-color: var(--blue);
   }
+
+  &:disabled {
+    background: var(--lighter-grey);
+    color: var(--dark-grey);
+  }
 `;
 
 export const StyledInputBase = styled.input`

--- a/src/components/PlusMinusInput.js
+++ b/src/components/PlusMinusInput.js
@@ -3,7 +3,6 @@ import {Button, InputBase} from "./Forms";
 import styled from "styled-components";
 import PlusIcon from "../icons/Plus";
 import MinusIcon from "../icons/Minus";
-import {useTooltip} from "../hooks/useTooltip";
 
 const PlusMinusButton = styled(Button)`
   display: inline-block;

--- a/src/components/filterbar/LineInput.js
+++ b/src/components/filterbar/LineInput.js
@@ -36,23 +36,28 @@ const getSuggestions = (lines) => (value = "") => {
   const inputValue = value.trim().toLowerCase();
   const inputLength = inputValue.length;
 
-  const sortedLines = sortBy(lines, ({lineId}) => {
-    const parsedLine = parseLineNumber(lineId);
-    // Convert a letter line id to a number, so that a => 1, b => 2 etc.
-    const lineNum = isNaN(parseInt(parsedLine, 10))
-      ? parsedLine.charCodeAt(0) - 97
-      : parsedLine;
+  const filteredLines =
+    inputLength === 0
+      ? lines
+      : lines.filter((line) => {
+          return parseLineNumber(line.lineId.toLowerCase()).includes(
+            inputValue.slice(0, inputLength)
+          );
+        });
 
+  const sortedLines = sortBy(filteredLines, ({lineId}) => {
+    const parsedLineId = parseLineNumber(lineId);
+    const numericLineId = parsedLineId.replace(/[^0-9]*/g, "");
+
+    if (!numericLineId) {
+      return getTransportType(lineId, true);
+    }
+
+    const lineNum = parseInt(numericLineId, 10);
     return getTransportType(lineId, true) + lineNum;
   });
 
-  return inputLength === 0
-    ? sortedLines
-    : sortedLines.filter((line) => {
-        return parseLineNumber(line.lineId.toLowerCase()).includes(
-          inputValue.slice(0, inputLength)
-        );
-      });
+  return sortedLines;
 };
 
 @observer

--- a/src/components/map/HfpMarkerLayer.js
+++ b/src/components/map/HfpMarkerLayer.js
@@ -1,18 +1,16 @@
 import React, {Component} from "react";
-import PropTypes from "prop-types";
-import {observer} from "mobx-react";
+import {observer, inject} from "mobx-react";
 import "./Map.css";
 import VehicleMarker from "./VehicleMarker";
 import DivIcon from "../../helpers/DivIcon";
 import HfpTooltip from "./HfpTooltip";
 import {observable, action} from "mobx";
+import {app} from "mobx-app";
+import getJourneyId from "../../helpers/getJourneyId";
 
+@inject(app("Journey"))
 @observer
 class HfpMarkerLayer extends Component {
-  static propTypes = {
-    onMarkerClick: PropTypes.func.isRequired,
-  };
-
   markerRef = React.createRef();
 
   @observable
@@ -22,10 +20,13 @@ class HfpMarkerLayer extends Component {
     this.tooltipOpen = setTo;
   });
 
-  onMarkerClick = (positionWhenClicked) => () => {
-    const {onMarkerClick} = this.props;
+  onMarkerClick = () => {
     this.toggleTooltip();
-    onMarkerClick(positionWhenClicked);
+    const {Journey, state, currentPosition: journey} = this.props;
+
+    if (journey && getJourneyId(state.selectedJourney) !== getJourneyId(journey)) {
+      Journey.setSelectedJourney(journey);
+    }
   };
 
   render() {
@@ -38,7 +39,7 @@ class HfpMarkerLayer extends Component {
     return (
       <DivIcon
         ref={this.markerRef} // Needs ref for testing
-        onClick={this.onMarkerClick(position)}
+        onClick={this.onMarkerClick}
         position={[position.lat, position.long]}
         iconSize={isSelectedJourney ? [36, 36] : [20, 20]}
         icon={

--- a/src/components/map/HfpMarkerLayer.js
+++ b/src/components/map/HfpMarkerLayer.js
@@ -29,7 +29,7 @@ class HfpMarkerLayer extends Component {
   };
 
   render() {
-    const {currentPosition: position} = this.props;
+    const {currentPosition: position, isSelectedJourney = false} = this.props;
 
     if (!position) {
       return null;
@@ -40,9 +40,11 @@ class HfpMarkerLayer extends Component {
         ref={this.markerRef} // Needs ref for testing
         onClick={this.onMarkerClick(position)}
         position={[position.lat, position.long]}
-        iconSize={[36, 36]}
-        icon={<VehicleMarker position={position} />}
-        pane="hfp-markers">
+        iconSize={isSelectedJourney ? [36, 36] : [28, 28]}
+        icon={
+          <VehicleMarker isSelectedJourney={isSelectedJourney} position={position} />
+        }
+        pane={isSelectedJourney ? "hfp-markers-primary" : "hfp-markers"}>
         <HfpTooltip
           key={`permanent=${this.tooltipOpen}`}
           position={position}

--- a/src/components/map/HfpMarkerLayer.js
+++ b/src/components/map/HfpMarkerLayer.js
@@ -40,7 +40,7 @@ class HfpMarkerLayer extends Component {
         ref={this.markerRef} // Needs ref for testing
         onClick={this.onMarkerClick(position)}
         position={[position.lat, position.long]}
-        iconSize={isSelectedJourney ? [36, 36] : [28, 28]}
+        iconSize={isSelectedJourney ? [36, 36] : [20, 20]}
         icon={
           <VehicleMarker isSelectedJourney={isSelectedJourney} position={position} />
         }

--- a/src/components/map/HfpMarkerLayer.test.js
+++ b/src/components/map/HfpMarkerLayer.test.js
@@ -3,7 +3,7 @@ import "jest-dom/extend-expect";
 import "jest-styled-components";
 import HfpMarkerLayer from "./HfpMarkerLayer";
 import {Map, TileLayer, Pane} from "react-leaflet";
-import {render, fireEvent, cleanup} from "react-testing-library";
+import {render, cleanup} from "react-testing-library";
 import VehicleMarker from "./VehicleMarker";
 
 describe("HfpMarkerLayer", () => {

--- a/src/components/map/HfpMarkerLayer.test.js
+++ b/src/components/map/HfpMarkerLayer.test.js
@@ -23,7 +23,6 @@ describe("HfpMarkerLayer", () => {
       mode: "BUS",
     };
 
-    const onClick = jest.fn();
     const {lat, long} = position;
     const markerRef = React.createRef();
 
@@ -31,23 +30,17 @@ describe("HfpMarkerLayer", () => {
       <Map center={[lat, long]} zoom={13}>
         <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
         <Pane name="hfp-markers" style={{zIndex: 430}} />
-        <HfpMarkerLayer
-          ref={markerRef}
-          currentPosition={position}
-          onMarkerClick={onClick}
-        />
+        <HfpMarkerLayer ref={markerRef} currentPosition={position} />
       </Map>
     );
 
     // Nice path
-    expect(markerRef.current.markerRef.current.leafletElement._latlng).toEqual({
+    expect(
+      markerRef.current.wrappedInstance.markerRef.current.leafletElement._latlng
+    ).toEqual({
       lat,
       lng: long,
     });
-
-    fireEvent.click(markerRef.current.markerRef.current.leafletElement._icon);
-
-    return expect(onClick).toHaveBeenCalledWith(position);
   });
 
   test("The icon gets the correct color and vehicle icon", () => {

--- a/src/components/map/LeafletMap.js
+++ b/src/components/map/LeafletMap.js
@@ -137,10 +137,10 @@ class LeafletMap extends Component {
           <Pane name="mapillary-location" style={{zIndex: 400}} />
           <Pane name="route-lines" style={{zIndex: 410}} />
           <Pane name="hfp-lines" style={{zIndex: 420}} />
-          <Pane name="hfp-markers" style={{zIndex: 430}} />
           <Pane name="stop-radius" style={{zIndex: 440}} />
           <Pane name="selected-stop-radius" style={{zIndex: 445}} />
           <Pane name="stops" style={{zIndex: 450}} />
+          <Pane name="hfp-markers" style={{zIndex: 460}} />
           <ZoomControl position="topright" />
           {children}
         </Map>

--- a/src/components/map/LeafletMap.js
+++ b/src/components/map/LeafletMap.js
@@ -141,6 +141,7 @@ class LeafletMap extends Component {
           <Pane name="selected-stop-radius" style={{zIndex: 445}} />
           <Pane name="stops" style={{zIndex: 450}} />
           <Pane name="hfp-markers" style={{zIndex: 460}} />
+          <Pane name="hfp-markers-primary" style={{zIndex: 465}} />
           <ZoomControl position="topright" />
           {children}
         </Map>

--- a/src/components/map/MapContent.js
+++ b/src/components/map/MapContent.js
@@ -16,14 +16,13 @@ import {areaEventsStyles} from "../../stores/UIStore";
 import SimpleHfpLayer from "./SimpleHfpLayer";
 import {createRouteKey} from "../../helpers/keys";
 
-@inject(app("Journey", "Filters"))
+@inject(app("Journey"))
 @observer
 class MapContent extends Component {
   onClickVehicleMarker = (journey) => {
-    const {Journey, Filters, state} = this.props;
+    const {Journey, state} = this.props;
 
     if (journey && getJourneyId(state.selectedJourney) !== getJourneyId(journey)) {
-      Filters.setVehicle(journey.unique_vehicle_id);
       Journey.setSelectedJourney(journey);
     }
   };
@@ -113,7 +112,6 @@ class MapContent extends Component {
                 }
 
                 const isSelectedJourney = selectedJourneyId === journeyId;
-
                 const currentPosition = timePositions.get(journeyId);
 
                 return [
@@ -139,6 +137,7 @@ class MapContent extends Component {
                     onMarkerClick={this.onClickVehicleMarker}
                     currentPosition={currentPosition}
                     journeyId={journeyId}
+                    isSelectedJourney={isSelectedJourney}
                   />,
                 ];
               })}

--- a/src/components/map/MapContent.js
+++ b/src/components/map/MapContent.js
@@ -16,17 +16,9 @@ import {areaEventsStyles} from "../../stores/UIStore";
 import SimpleHfpLayer from "./SimpleHfpLayer";
 import {createRouteKey} from "../../helpers/keys";
 
-@inject(app("Journey"))
+@inject(app("state"))
 @observer
 class MapContent extends Component {
-  onClickVehicleMarker = (journey) => {
-    const {Journey, state} = this.props;
-
-    if (journey && getJourneyId(state.selectedJourney) !== getJourneyId(journey)) {
-      Journey.setSelectedJourney(journey);
-    }
-  };
-
   render() {
     const {
       journeys = [],
@@ -134,7 +126,6 @@ class MapContent extends Component {
                   ) : null,
                   <HfpMarkerLayer
                     key={`hfp_markers_${journeyId}`}
-                    onMarkerClick={this.onClickVehicleMarker}
                     currentPosition={currentPosition}
                     journeyId={journeyId}
                     isSelectedJourney={isSelectedJourney}
@@ -157,9 +148,9 @@ class MapContent extends Component {
                 return (
                   <HfpMarkerLayer
                     key={`hfp_markers_${journeyId}`}
-                    onMarkerClick={this.onClickVehicleMarker}
                     currentPosition={event}
                     journeyId={journeyId}
+                    isSelectedJourney={false}
                   />
                 );
               }

--- a/src/components/map/VehicleMarker.js
+++ b/src/components/map/VehicleMarker.js
@@ -11,7 +11,6 @@ const IconWrapper = styled.span`
   border-radius: 50%;
   position: relative;
   background-color: ${({color}) => color};
-  opacity: ${({translucent}) => (translucent ? 0.65 : 1)};
 `;
 
 const Icon = styled.div`
@@ -23,15 +22,17 @@ const Icon = styled.div`
   border-radius: 50%;
   position: relative;
   z-index: 10;
-  overflow: hidden;
   transform: ${({rotation}) => `rotate(${rotation}deg)`};
+  background-color: ${({color}) => color};
 
   &:before {
     content: " ";
-    width: 90%;
-    height: 90%;
-    margin: 0 0 1px;
+    width: 100%;
+    height: 100%;
+    margin: 0;
     display: block;
+    transform: scale(0.925, 0.925);
+    mix-blend-mode: lighten;
   }
 `;
 
@@ -43,8 +44,8 @@ const Indicator = styled.span`
   left: ${({position = "left"}) => (position === "left" ? "-7px" : "auto")};
   background: ${({color = "var(--dark-blue)"}) => color};
   border: 2px solid white;
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
 `;
 
@@ -66,9 +67,9 @@ const HeadingArrow = styled.span`
   width: 0;
   height: 0;
   position: absolute;
-  top: ${({small}) => (small ? "-24px" : "-29px")};
-  left: ${({small}) => (small ? "4px" : "5px")};
-  border-width: ${({small}) => (small ? "14px 10px" : "17px 13px")};
+  top: ${({small}) => (small ? "-14px" : "-29px")};
+  left: ${({small}) => (small ? "2px" : "5px")};
+  border-width: ${({small}) => (small ? "9px 8px" : "17px 13px")};
   border-color: transparent transparent ${({color = "var(--blue)"}) => color}
     transparent;
   border-style: solid;
@@ -93,11 +94,13 @@ class VehicleMarker extends React.Component {
         isStopped={isStopped}
         data-testid="hfp-marker-icon">
         <Icon
+          color={color}
           data-testid="icon-icon"
           // The mode className applies the vehicle icon
           className={get(position, "mode", "BUS").toUpperCase()}
         />
         <RotationWrapper
+          color={color}
           rotation={get(position, "hdg", 0)}
           data-testid="icon-rotation">
           {position.drst && <Indicator position="right" color="var(--dark-blue)" />}

--- a/src/components/map/VehicleMarker.js
+++ b/src/components/map/VehicleMarker.js
@@ -11,6 +11,7 @@ const IconWrapper = styled.span`
   border-radius: 50%;
   position: relative;
   background-color: ${({color}) => color};
+  opacity: ${({translucent}) => (translucent ? 0.65 : 1)};
 `;
 
 const Icon = styled.div`
@@ -65,9 +66,9 @@ const HeadingArrow = styled.span`
   width: 0;
   height: 0;
   position: absolute;
-  top: -29px;
-  left: 5px;
-  border-width: 17px 13px;
+  top: ${({small}) => (small ? "-24px" : "-29px")};
+  left: ${({small}) => (small ? "4px" : "5px")};
+  border-width: ${({small}) => (small ? "14px 10px" : "17px 13px")};
   border-color: transparent transparent ${({color = "var(--blue)"}) => color}
     transparent;
   border-style: solid;
@@ -76,15 +77,21 @@ const HeadingArrow = styled.span`
 
 class VehicleMarker extends React.Component {
   render() {
-    const {position} = this.props;
+    const {position, isSelectedJourney = false} = this.props;
 
     const color = getModeColor(get(position, "mode", "").toUpperCase());
 
     // The spd value can be a bit flaky, so I decided that under 2 m/s is stopped enough.
     const isStopped = position.spd < 2;
 
+    // TODO: Highlight non-selected journeys
+
     return (
-      <IconWrapper color={color} isStopped={isStopped} data-testid="hfp-marker-icon">
+      <IconWrapper
+        translucent={!isSelectedJourney}
+        color={color}
+        isStopped={isStopped}
+        data-testid="hfp-marker-icon">
         <Icon
           data-testid="icon-icon"
           // The mode className applies the vehicle icon
@@ -96,7 +103,11 @@ class VehicleMarker extends React.Component {
           {position.drst && <Indicator position="right" color="var(--dark-blue)" />}
           {position.full && <Indicator position="left" color="var(--red)" />}
           {!isStopped && (
-            <HeadingArrow className="hfp-marker-heading" color={color} />
+            <HeadingArrow
+              small={!isSelectedJourney}
+              className="hfp-marker-heading"
+              color={color}
+            />
           )}
         </RotationWrapper>
       </IconWrapper>

--- a/src/components/map/VehicleMarker.js
+++ b/src/components/map/VehicleMarker.js
@@ -32,7 +32,6 @@ const Icon = styled.div`
     margin: 0;
     display: block;
     transform: scale(0.925, 0.925);
-    mix-blend-mode: lighten;
   }
 `;
 

--- a/src/components/sidepanel/AreaJourneyList.js
+++ b/src/components/sidepanel/AreaJourneyList.js
@@ -45,24 +45,18 @@ const TimeSlot = styled.span`
   text-align: right;
 `;
 
-@inject(app("Journey", "Time", "Filters", "UI"))
+@inject(app("Journey", "Time", "UI"))
 @observer
 class AreaJourneyList extends Component {
   selectJourney = (journey) => (e) => {
     e.preventDefault();
-    const {Filters, Journey, state} = this.props;
+    const {Journey, state} = this.props;
 
     if (journey) {
       const journeyId = getJourneyId(journey);
 
       // Only set these if the journey is truthy and was not already selected
       if (journeyId && getJourneyId(state.selectedJourney) !== journeyId) {
-        const route = {
-          routeId: journey.route_id,
-          direction: parseInt(journey.direction_id, 10),
-        };
-
-        Filters.setRoute(route);
         Journey.setSelectedJourney(journey);
       } else {
         Journey.setSelectedJourney(null);

--- a/src/components/sidepanel/VehicleJourneys.js
+++ b/src/components/sidepanel/VehicleJourneys.js
@@ -82,13 +82,6 @@ class VehicleJourneys extends Component {
         Time.setTime(journey.journey_start_time);
         Filters.setVehicle(journey.unique_vehicle_id);
       }
-
-      const route = {
-        routeId: journey.route_id,
-        direction: journey.direction_id + "",
-      };
-
-      Filters.setRoute(route);
     }
 
     Journey.setSelectedJourney(journey);

--- a/src/components/sidepanel/journeyDetails/OriginStop.js
+++ b/src/components/sidepanel/journeyDetails/OriginStop.js
@@ -71,7 +71,7 @@ const OriginStop = observer(
       departure,
       plannedDepartureMoment,
       departureMoment,
-      delayType,
+      departureDelayType,
       departureDiff,
       departureEvent,
       arrivalEvent,
@@ -135,8 +135,11 @@ const OriginStop = observer(
           <StopDepartureTime onClick={selectDepartureTime}>
             <PlainSlot>{plannedDepartureMoment.format("HH:mm:ss")}</PlainSlot>
             <ColoredBackgroundSlot
-              color={delayType === "late" ? "var(--dark-grey)" : "white"}
-              backgroundColor={getTimelinessColor(delayType, "var(--light-green)")}>
+              color={departureDelayType === "late" ? "var(--dark-grey)" : "white"}
+              backgroundColor={getTimelinessColor(
+                departureDelayType,
+                "var(--light-green)"
+              )}>
               {departureDiff.sign === "-" ? "-" : ""}
               {doubleDigit(get(departureDiff, "minutes", 0))}:
               {doubleDigit(get(departureDiff, "seconds", 0))}

--- a/src/helpers/checkBrowser.js
+++ b/src/helpers/checkBrowser.js
@@ -1,0 +1,14 @@
+import Sniffer from "snifferjs";
+
+const allowedEngines = ["webkit", "gecko"];
+
+export function checkBrowser() {
+  const ua = window.navigator.userAgent;
+  const engine = Sniffer(ua).browser.engine;
+
+  if (!allowedEngines.includes(engine)) {
+    window.alert(
+      "Your browser is not supported. Please use Transitlog with Chrome or Firefox."
+    );
+  }
+}

--- a/src/helpers/getTransportType.js
+++ b/src/helpers/getTransportType.js
@@ -13,7 +13,7 @@ function getTransportType(lineId, numeric = false) {
 
   if (/^300[12]/.test(lineType)) {
     if (numeric) {
-      return 100;
+      return 15;
     }
 
     return "RAIL";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 /* eslint-disable import/first */
+import {checkBrowser} from "./helpers/checkBrowser";
+checkBrowser();
+
 import moment from "moment-timezone";
 import {TIMEZONE} from "./constants";
 

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -5,6 +5,7 @@ import filterActions from "./filterActions";
 import {setPathName} from "./UrlManager";
 import get from "lodash/get";
 import timeActions from "./timeActions";
+import {setResetListener} from "./FilterStore";
 
 export function createJourneyPath(journey) {
   const dateStr = journey.oday.replace(/-/g, "");
@@ -35,7 +36,6 @@ export function createCompositeJourney(date, route, time, instance = 0) {
 export default (state) => {
   const filters = filterActions(state);
   const time = timeActions(state);
-  let prevVehicle = null;
 
   const setSelectedJourney = action(
     "Set selected journey",
@@ -46,14 +46,12 @@ export default (state) => {
           getJourneyId(state.selectedJourney) === getJourneyId(hfpItem))
       ) {
         state.selectedJourney = null;
-        filters.setVehicle(prevVehicle);
+        filters.setVehicle(null);
         setPathName("/");
       } else if (hfpItem) {
         state.selectedJourney = pickJourneyProps(hfpItem);
 
         if (hfpItem.unique_vehicle_id) {
-          // Remember the previous selection so that we can set it back when deselecting the journey.
-          prevVehicle = state.vehicle || null;
           filters.setVehicle(hfpItem.unique_vehicle_id);
         }
 

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -50,6 +50,11 @@ export default (state) => {
       } else if (hfpItem) {
         state.selectedJourney = pickJourneyProps(hfpItem);
 
+        filters.setRoute({
+          routeId: hfpItem.route_id,
+          direction: hfpItem.direction_id + "",
+        });
+
         if (hfpItem.unique_vehicle_id) {
           filters.setVehicle(hfpItem.unique_vehicle_id);
         }

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -5,7 +5,6 @@ import filterActions from "./filterActions";
 import {setPathName} from "./UrlManager";
 import get from "lodash/get";
 import timeActions from "./timeActions";
-import {setResetListener} from "./FilterStore";
 
 export function createJourneyPath(journey) {
   const dateStr = journey.oday.replace(/-/g, "");

--- a/yarn.lock
+++ b/yarn.lock
@@ -10215,6 +10215,11 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+snifferjs@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/snifferjs/-/snifferjs-3.1.1.tgz#26c6b41b51a395fe6625e4414613c2a3a49c528c"
+  integrity sha1-Jsa0G1Gjlf5mJeRBRhPCo6ScUow=
+
 sockjs-client@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177"


### PR DESCRIPTION
- Alert message when using the wrong browser. Fixes #233.
- Sort lines in lineinput numerically and ensure that trains are first.
- Move vehicle markers on top of other stop features
- Fix vehicle selection not getting cleared on reset
- Ensure disabled field state is visible
- Fixes departure diff color of the first stop in the journey sidebar. Fixes #232.
- Small icon style for vehicle markers that are not the selected journey. Also fixes vehicle marker click action.