### PR TITLE
Better stop timetables

### DIFF
--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -12,7 +12,7 @@ const spin = keyframes`
   }
 `;
 
-const Loading = styled.div`
+const LoadingIndicator = styled.div`
   background: white;
   border-radius: 50%;
   padding: 0.75rem;
@@ -51,7 +51,7 @@ const Loading = styled.div`
 
 const LoadingContainer = styled.div`
   position: absolute;
-  top: 8rem;
+  top: 1rem;
   left: 0;
   width: 100%;
   display: flex;
@@ -74,15 +74,17 @@ const LoadingContainer = styled.div`
       : ""};
 `;
 
-export default ({className, inline, size}) => {
+const Loading = ({className, inline, size}) => {
   const defaultSize = inline ? 24 : 35;
 
   return (
-    <Loading inline={inline} className={className}>
+    <LoadingIndicator inline={inline} className={className}>
       <Spinner width={size || defaultSize} height={size || defaultSize} />
-    </Loading>
+    </LoadingIndicator>
   );
 };
+
+export default Loading;
 
 export const LoadingDisplay = ({loading = false, className, inline, size}) => (
   <LoadingContainer className={className} loading={loading}>

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -85,7 +85,7 @@ export default ({className, inline, size}) => {
 };
 
 export const LoadingDisplay = ({loading = false, className, inline, size}) => (
-  <LoadingContainer loading={loading}>
-    <Loading className={className} inline={inline} size={size} />
+  <LoadingContainer className={className} loading={loading}>
+    <Loading inline={inline} size={size} />
   </LoadingContainer>
 );

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -49,6 +49,31 @@ const Loading = styled.div`
   }
 `;
 
+const LoadingContainer = styled.div`
+  position: absolute;
+  top: 8rem;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+  user-select: none;
+  transition: opacity 0.1s ease-out, transform 0.2s ease-out;
+  transform: translateY(-5rem);
+  z-index: 10;
+
+  ${({loading = false}) =>
+    loading
+      ? css`
+          opacity: 1;
+          pointer-events: all;
+          transform: translateY(0);
+        `
+      : ""};
+`;
+
 export default ({className, inline, size}) => {
   const defaultSize = inline ? 24 : 35;
 
@@ -58,3 +83,9 @@ export default ({className, inline, size}) => {
     </Loading>
   );
 };
+
+export const LoadingDisplay = ({loading = false, className, inline, size}) => (
+  <LoadingContainer loading={loading}>
+    <Loading className={className} inline={inline} size={size} />
+  </LoadingContainer>
+);

--- a/src/components/map/RouteStopsLayer.js
+++ b/src/components/map/RouteStopsLayer.js
@@ -1,6 +1,5 @@
 import React from "react";
 import flow from "lodash/flow";
-import uniqBy from "lodash/uniqBy";
 import RouteStop from "./RouteStop";
 import {observer} from "mobx-react-lite";
 import StopsByRouteQuery from "../../queries/StopsByRouteQuery";

--- a/src/components/sidepanel/SidepanelList.js
+++ b/src/components/sidepanel/SidepanelList.js
@@ -1,9 +1,9 @@
 import React, {Component} from "react";
 import {observer, inject} from "mobx-react";
-import styled, {css} from "styled-components";
-import Loading from "../Loading";
+import styled from "styled-components";
 import {action, observable, reaction} from "mobx";
 import {app} from "mobx-app";
+import {LoadingDisplay} from "../Loading";
 
 const ListWrapper = styled.div`
   height: 100%;
@@ -42,31 +42,6 @@ const ScrollContainer = styled.div`
   left: 0;
   width: 100%;
   height: auto;
-`;
-
-const LoadingContainer = styled.div`
-  position: absolute;
-  top: 8rem;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  opacity: 0;
-  pointer-events: none;
-  user-select: none;
-  transition: opacity 0.1s ease-out, transform 0.2s ease-out;
-  transform: translateY(-5rem);
-  z-index: 10;
-
-  ${({loading = false}) =>
-    loading
-      ? css`
-          opacity: 1;
-          pointer-events: all;
-          transform: translateY(0);
-        `
-      : ""};
 `;
 
 @inject(app("state"))
@@ -163,11 +138,7 @@ class SidepanelList extends Component {
           <ScrollContainer>
             {children(this.scrollPositionRef, this.updateScrollOffset)}
           </ScrollContainer>
-          {!live && (
-            <LoadingContainer loading={loading}>
-              <Loading />
-            </LoadingContainer>
-          )}
+          {!live && <LoadingDisplay loading={loading} />}
         </ListRows>
       </ListWrapper>
     );

--- a/src/components/sidepanel/TimetableDeparture.js
+++ b/src/components/sidepanel/TimetableDeparture.js
@@ -15,7 +15,6 @@ import {
 } from "../TagButton";
 import {getTimelinessColor} from "../../helpers/timelinessColor";
 import styled from "styled-components";
-import Loading from "../Loading";
 import getJourneyId from "../../helpers/getJourneyId";
 import {createCompositeJourney} from "../../stores/journeyActions";
 
@@ -37,13 +36,6 @@ const LineSlot = styled(ColoredSlot)`
 
 const PlannedTimeSlot = styled(PlainSlot)`
   min-width: 5.25rem;
-`;
-
-const InlineLoading = styled(Loading).attrs({inline: true, size: 18})`
-  color: red;
-  align-self: center;
-  margin-left: auto;
-  margin-top: 5px;
 `;
 
 const TimingIcon = styled.img`

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -157,7 +157,7 @@ class TimetablePanel extends Component {
     );
   }
 
-  renderRow = (list, props) => ({key, index, style, isScrolling, isVisible}) => {
+  renderRow = (props) => (list) => ({key, index, style, isScrolling, isVisible}) => {
     const departure = list[index];
 
     return (
@@ -185,7 +185,7 @@ class TimetablePanel extends Component {
         date={date}
         scrollToIndex={focusedIndex !== -1 ? focusedIndex : undefined}
         list={departures}
-        renderRow={renderRow}
+        renderRow={renderRow(departures)}
         rowHeight={35}
         loading={loading}
         header={
@@ -266,13 +266,6 @@ class TimetablePanel extends Component {
       })
     );
 
-    const rowRenderer = this.renderRow(sortedDepartures, {
-      selectedJourney,
-      onClick: this.selectAsJourney,
-      stop,
-      date,
-    });
-
     const selectedJourneyId = getJourneyId(selectedJourney);
 
     const focusedDeparture = selectedJourneyId
@@ -298,6 +291,13 @@ class TimetablePanel extends Component {
     return (
       <DepartureHfpQuery stopId={stopId} date={date}>
         {({events: stopEvents = [], loading: eventsLoading}) => {
+          const rowRenderer = this.renderRow({
+            selectedJourney,
+            onClick: this.selectAsJourney,
+            stop,
+            date,
+          });
+
           if (stopEvents.length === 0) {
             return this.renderList(
               sortedDepartures,

--- a/src/components/sidepanel/TimetablePanel.js
+++ b/src/components/sidepanel/TimetablePanel.js
@@ -298,7 +298,7 @@ class TimetablePanel extends Component {
     return (
       <DepartureHfpQuery stopId={stopId} date={date}>
         {({events: stopEvents = [], loading: eventsLoading}) => {
-          if (stopEvents.length === 0 || eventsLoading) {
+          if (stopEvents.length === 0) {
             return this.renderList(
               sortedDepartures,
               rowRenderer,

--- a/src/components/sidepanel/VirtualizedSidepanelList.js
+++ b/src/components/sidepanel/VirtualizedSidepanelList.js
@@ -53,14 +53,15 @@ class VirtualizedSidepanelList extends Component {
                 estimatedRowSize={35}
                 height={height}
                 width={width}
+                loading={loading}
                 rowCount={list.length}
                 rowHeight={rowHeight}
                 rowRenderer={renderRow}
               />
             )}
           </AutoSizer>
-          <LoadingDisplay loading={loading} />
         </div>
+        <LoadingDisplay loading={loading} />
       </ListWrapper>
     );
   }

--- a/src/components/sidepanel/VirtualizedSidepanelList.js
+++ b/src/components/sidepanel/VirtualizedSidepanelList.js
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import {observer} from "mobx-react";
-import styled, {css} from "styled-components";
-import Loading from "../Loading";
+import styled from "styled-components";
+import {LoadingDisplay} from "../Loading";
 import {List, AutoSizer} from "react-virtualized";
 
 const ListWrapper = styled.div`
@@ -26,31 +26,6 @@ const ListHeader = styled.header`
   align-items: start;
   padding: 0.75rem 1rem;
   color: var(--grey);
-`;
-
-const LoadingContainer = styled.div`
-  position: absolute;
-  top: 8rem;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  opacity: 0;
-  pointer-events: none;
-  user-select: none;
-  transition: opacity 0.1s ease-out, transform 0.2s ease-out;
-  transform: translateY(-5rem);
-  z-index: 10;
-
-  ${({loading = false}) =>
-    loading
-      ? css`
-          opacity: 1;
-          pointer-events: all;
-          transform: translateY(0);
-        `
-      : ""};
 `;
 
 @observer
@@ -84,9 +59,7 @@ class VirtualizedSidepanelList extends Component {
               />
             )}
           </AutoSizer>
-          <LoadingContainer loading={loading}>
-            <Loading />
-          </LoadingContainer>
+          <LoadingDisplay loading={loading} />
         </div>
       </ListWrapper>
     );

--- a/src/components/sidepanel/VirtualizedSidepanelList.js
+++ b/src/components/sidepanel/VirtualizedSidepanelList.js
@@ -60,8 +60,8 @@ class VirtualizedSidepanelList extends Component {
               />
             )}
           </AutoSizer>
+          <LoadingDisplay loading={loading} />
         </div>
-        <LoadingDisplay loading={loading} />
       </ListWrapper>
     );
   }

--- a/src/components/sidepanel/journeyDetails/JourneyDetails.js
+++ b/src/components/sidepanel/journeyDetails/JourneyDetails.js
@@ -5,7 +5,7 @@ import {observer, inject} from "mobx-react";
 import {app} from "mobx-app";
 import get from "lodash/get";
 import JourneyStops from "./JourneyStops";
-import Loading from "../../Loading";
+import {LoadingDisplay} from "../../Loading";
 import JourneyInfo from "./JourneyInfo";
 import DestinationStop from "./DestinationStop";
 import withRoute from "../../../hoc/withRoute";
@@ -38,7 +38,7 @@ const StopsListWrapper = styled.div`
   padding: 2rem 0 1rem;
 `;
 
-const LoadingContainer = styled.div`
+const Loading = styled(LoadingDisplay)`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -133,9 +133,7 @@ class JourneyDetails extends React.Component {
                 />
               </StopsListWrapper>
             ) : loading ? (
-              <LoadingContainer>
-                <Loading />
-              </LoadingContainer>
+              <Loading loading={true} />
             ) : null}
           </JourneyPanelContent>
         </ScrollContainer>


### PR DESCRIPTION
I figured out that doing a distinct query for stop HFP times is quite quick, and I want to use this query for the transitlog-server. But first I needed to test the feasibility which, if successful, would speed up the timetable view in the UI nicely before we connect the server. So here's the PR for that.