### PR TITLE
Handle null coordinates

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -134,12 +134,15 @@ function App({state, UI}) {
                                                     )
                                                   : false;
 
-                                              const centerPosition = selectedJourneyPosition
-                                                ? latLng([
-                                                    selectedJourneyPosition.lat,
-                                                    selectedJourneyPosition.long,
-                                                  ])
-                                                : stopPosition;
+                                              const {
+                                                lat,
+                                                long,
+                                              } = selectedJourneyPosition;
+
+                                              const centerPosition =
+                                                lat && long
+                                                  ? latLng([lat, long])
+                                                  : stopPosition;
 
                                               if (centerPosition) {
                                                 setMapView(centerPosition);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -134,10 +134,8 @@ function App({state, UI}) {
                                                     )
                                                   : false;
 
-                                              const {
-                                                lat,
-                                                long,
-                                              } = selectedJourneyPosition;
+                                              const {lat, long} =
+                                                selectedJourneyPosition || {};
 
                                               const centerPosition =
                                                 lat && long

--- a/src/components/JourneyPosition.js
+++ b/src/components/JourneyPosition.js
@@ -1,6 +1,7 @@
 import {Component} from "react";
 import {observer, inject} from "mobx-react";
 import {reaction, observable, action} from "mobx";
+import findLast from "lodash/findLast";
 
 @inject("state")
 @observer
@@ -34,7 +35,11 @@ class JourneyPosition extends Component {
   getLivePositions = (journeys) => {
     journeys.forEach(({journeyId, events = []}) => {
       if (events.length !== 0) {
-        this.setHfpPosition(journeyId, events[events.length - 1]);
+        const event = findLast(events, (pos) => !!pos.lat && !!pos.long);
+
+        if (event) {
+          this.setHfpPosition(journeyId, event);
+        }
       }
     });
   };
@@ -69,8 +74,11 @@ class JourneyPosition extends Component {
   // This is a performance optimization.
   indexPositions = (positions) => {
     return positions.reduce((positionIndex, position) => {
-      const key = position.received_at_unix;
-      positionIndex.set(key, position);
+      if (position.lat && position.long) {
+        const key = position.received_at_unix;
+        positionIndex.set(key, position);
+      }
+
       return positionIndex;
     }, new Map());
   };

--- a/src/components/JourneyPosition.test.js
+++ b/src/components/JourneyPosition.test.js
@@ -19,9 +19,9 @@ describe("JourneyPosition", () => {
       {
         journeyId: "test",
         events: [
-          {received_at_unix: 1},
-          {received_at_unix: 2},
-          {received_at_unix: 3},
+          {received_at_unix: 1, lat: 1, long: 1},
+          {received_at_unix: 2, lat: 1, long: 1},
+          {received_at_unix: 3, lat: 1, long: 1},
         ],
       },
     ];
@@ -53,9 +53,9 @@ describe("JourneyPosition", () => {
       {
         journeyId: "test",
         events: [
-          {received_at_unix: 10},
-          {received_at_unix: 20},
-          {received_at_unix: 30},
+          {received_at_unix: 10, lat: 1, long: 1},
+          {received_at_unix: 20, lat: 1, long: 1},
+          {received_at_unix: 30, lat: 1, long: 1},
         ],
       },
     ];
@@ -85,9 +85,9 @@ describe("JourneyPosition", () => {
       {
         journeyId: "test",
         events: [
-          {received_at_unix: 10},
-          {received_at_unix: 20},
-          {received_at_unix: 30},
+          {received_at_unix: 10, lat: 1, long: 1},
+          {received_at_unix: 20, lat: 1, long: 1},
+          {received_at_unix: 30, lat: 1, long: 1},
         ],
       },
     ];
@@ -121,9 +121,9 @@ describe("JourneyPosition", () => {
       {
         journeyId: "test",
         events: [
-          {received_at_unix: 10},
-          {received_at_unix: 20},
-          {received_at_unix: 30},
+          {received_at_unix: 10, lat: 1, long: 1},
+          {received_at_unix: 20, lat: 1, long: 1},
+          {received_at_unix: 30, lat: 1, long: 1},
         ],
       },
     ];
@@ -154,9 +154,9 @@ describe("JourneyPosition", () => {
       {
         journeyId: "test",
         events: [
-          {received_at_unix: 100},
-          {received_at_unix: 110},
-          {received_at_unix: 120},
+          {received_at_unix: 100, lat: 1, long: 1},
+          {received_at_unix: 110, lat: 1, long: 1},
+          {received_at_unix: 120, lat: 1, long: 1},
         ],
       },
     ];

--- a/src/components/SelectedJourneyEvents.js
+++ b/src/components/SelectedJourneyEvents.js
@@ -46,7 +46,7 @@ class SelectedJourneyEvents extends Component {
 
           const filteredEvents = positions
             // TODO: Fix when we have to deal with null coordinates
-            .filter((pos) => !!pos.lat && !!pos.long && !!pos.journey_start_time);
+            .filter((pos) => !!pos.journey_start_time);
 
           // Get the real date when this journey started. This will let us determine
           // on which side of the 24h+ day the journey happened.

--- a/src/components/map/HfpLayer.js
+++ b/src/components/map/HfpLayer.js
@@ -16,7 +16,7 @@ export function getLineChunksByDelay(positions, journeyId) {
   // Get only the positions from the same journey and create latLng items for Leaflet.
   // Additional data can be passed as the third array element which Leaflet won't touch.
   return positions
-    .filter((pos) => getJourneyId(pos) === journeyId)
+    .filter((pos) => getJourneyId(pos) === journeyId && !!pos.lat && !!pos.long)
     .reduce((allChunks, position) => {
       const positionDelay = get(position, "dl", 0);
       const delayType = getDelayType(-positionDelay); // "early", "late" or "on-time"

--- a/src/components/map/HfpLayer.test.js
+++ b/src/components/map/HfpLayer.test.js
@@ -8,6 +8,8 @@ describe("SimpleHfpLayer", () => {
     route_id: "routeid",
     direction_id: "direction",
     dl: 0,
+    lat: 1,
+    long: 1,
   };
 
   function createPositions() {

--- a/src/components/map/HfpMarkerLayer.js
+++ b/src/components/map/HfpMarkerLayer.js
@@ -32,7 +32,7 @@ class HfpMarkerLayer extends Component {
   render() {
     const {currentPosition: position, isSelectedJourney = false} = this.props;
 
-    if (!position) {
+    if (!position || !(position.lat && position.long)) {
       return null;
     }
 

--- a/src/components/map/SimpleHfpLayer.js
+++ b/src/components/map/SimpleHfpLayer.js
@@ -14,8 +14,9 @@ class SimpleHfpLayer extends Component {
   mouseOver = false;
 
   findHfpItem = (positions = [], latlng) => {
-    const hfpItem = positions.find((hfp) =>
-      latlng.equals(latLng(hfp.lat, hfp.long), 0.0001)
+    const hfpItem = positions.find(
+      (hfp) =>
+        hfp.lat && hfp.long && latlng.equals(latLng(hfp.lat, hfp.long), 0.0001)
     );
 
     return hfpItem || null;

--- a/src/components/sidepanel/Journeys.js
+++ b/src/components/sidepanel/Journeys.js
@@ -287,7 +287,7 @@ class Journeys extends Component {
                               {...applyTooltip("Journey list row")}
                               ref={journeyIsFocused ? scrollRef : null}
                               selected={journeyIsSelected}
-                              key={`journey_row_${journeyId}`}
+                              key={`journey_row_${journeyId}_${eventIndex}`}
                               onClick={this.selectJourney(journeyEvent)}>
                               <JourneyRowLeft
                                 {...applyTooltip("Planned journey time with data")}>

--- a/src/components/sidepanel/SidepanelList.js
+++ b/src/components/sidepanel/SidepanelList.js
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import {observer, inject} from "mobx-react";
 import styled from "styled-components";
-import {action, observable, reaction} from "mobx";
+import {action, observable} from "mobx";
 import {app} from "mobx-app";
 import {LoadingDisplay} from "../Loading";
 
@@ -57,22 +57,15 @@ class SidepanelList extends Component {
   listHeight = 0;
   updateScrollOffsetTimer = 0;
 
+  // Scrolls the list so that the focused element is in the middle.
   scrollTo = (offset) => {
-    if (this.scrollElementRef.current) {
+    if (offset && this.scrollElementRef.current) {
       this.scrollElementRef.current.scrollTop = offset - this.listHeight / 2;
     }
   };
 
   componentDidMount() {
-    this.disposeScrollOffsetReaction = reaction(
-      () => this.scrollOffset,
-      (offset) => {
-        if (!this.props.loading) {
-          this.scrollTo(offset);
-        }
-      }
-    );
-
+    // Set the height of the list on mount
     if (this.scrollElementRef.current) {
       this.listHeight = this.scrollElementRef.current.getBoundingClientRect().height;
     }
@@ -90,9 +83,12 @@ class SidepanelList extends Component {
         clearTimeout(this.updateScrollOffsetTimer);
       }
 
+      // Update the scroll offset 100 ms after any update.
+      // There must be a timer here otherwise the list may not be rendered
+      // before the scroll offset is read.
       this.updateScrollOffsetTimer = setTimeout(
         () => this.updateScrollOffset(reset),
-        500
+        300
       );
     }
   }
@@ -100,11 +96,12 @@ class SidepanelList extends Component {
   updateScrollOffset = (reset = false) => {
     const offset = this.getScrollOffset(reset);
 
-    if (!this.scrollOffset || offset !== this.scrollOffset) {
+    if (offset && (!this.scrollOffset || offset !== this.scrollOffset)) {
       this.setScrollOffset(offset);
     }
   };
 
+  // Get the scroll offset in pixels.
   // This method only gets a new position if the scrollOffset has not previously been set.
   // This behaviour can be overridden by setting the reset arg to true.
   getScrollOffset = (reset = false) => {
@@ -130,6 +127,8 @@ class SidepanelList extends Component {
       children = () => {},
       loading = false,
     } = this.props;
+
+    this.scrollTo(this.scrollOffset);
 
     return (
       <ListWrapper hasHeader={!!header}>

--- a/src/hooks/useJourneyWeather.js
+++ b/src/hooks/useJourneyWeather.js
@@ -15,13 +15,18 @@ export const useJourneyWeather = (events, journeyId) => {
 
   const bounds = useMemo(
     () =>
-      minPosition
+      minPosition &&
+      maxPosition &&
+      minPosition.lat &&
+      minPosition.long &&
+      maxPosition.lat &&
+      maxPosition.long
         ? latLngBounds(
             [minPosition.lat, minPosition.long],
             [maxPosition.lat, maxPosition.long]
           )
         : null,
-    [minPosition]
+    [minPosition, maxPosition]
   );
 
   const startDate = useMemo(

--- a/src/queries/HfpVehicleQuery.js
+++ b/src/queries/HfpVehicleQuery.js
@@ -53,7 +53,7 @@ class HfpVehicleQuery extends React.Component {
           }
 
           const vehicles = get(data, "vehicles", []).filter(
-            (event) => !!event.lat && !!event.long && event.journey_start_time
+            (event) => event.journey_start_time
           );
           return children({positions: vehicles, loading});
         }}

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -36,31 +36,34 @@ export default (state) => {
   const filters = filterActions(state);
   const time = timeActions(state);
 
-  const setSelectedJourney = action("Set selected journey", (hfpItem = null) => {
-    if (
-      !hfpItem ||
-      (state.selectedJourney &&
-        getJourneyId(state.selectedJourney) === getJourneyId(hfpItem))
-    ) {
-      state.selectedJourney = null;
-      filters.setVehicle(null);
-      setPathName("/");
-    } else if (hfpItem) {
-      state.selectedJourney = pickJourneyProps(hfpItem);
+  const setSelectedJourney = action(
+    "Set selected journey",
+    (hfpItem = null, instance = 0) => {
+      if (
+        !hfpItem ||
+        (state.selectedJourney &&
+          getJourneyId(state.selectedJourney) === getJourneyId(hfpItem))
+      ) {
+        state.selectedJourney = null;
+        filters.setVehicle(null);
+        setPathName("/");
+      } else if (hfpItem) {
+        state.selectedJourney = pickJourneyProps({...hfpItem, instance});
 
-      filters.setRoute({
-        routeId: hfpItem.route_id,
-        direction: hfpItem.direction_id + "",
-      });
+        filters.setRoute({
+          routeId: hfpItem.route_id,
+          direction: hfpItem.direction_id + "",
+        });
 
-      if (hfpItem.unique_vehicle_id) {
-        filters.setVehicle(hfpItem.unique_vehicle_id);
+        if (hfpItem.unique_vehicle_id) {
+          filters.setVehicle(hfpItem.unique_vehicle_id);
+        }
+
+        time.toggleLive(false);
+        setPathName(createJourneyPath(hfpItem));
       }
-
-      time.toggleLive(false);
-      setPathName(createJourneyPath(hfpItem));
     }
-  });
+  );
 
   const setJourneyVehicle = action((vehicleId) => {
     const {selectedJourney} = state;


### PR DESCRIPTION
Only the HFP polyline and markers need the event coordinates, so filter out nulls for them only. Other features like the stop list can still show the event time.

Also fixes other code to work with null coordinates where necessary.