### PR TITLE
Disable route inputs when there are none (#275)

### DIFF
--- a/src/components/filterbar/RouteInput.js
+++ b/src/components/filterbar/RouteInput.js
@@ -44,7 +44,11 @@ class RouteInput extends Component {
     const currentValue = createRouteId(route);
 
     return (
-      <Dropdown helpText="Select route" value={currentValue} onChange={this.onChange}>
+      <Dropdown
+        helpText="Select route"
+        disabled={routes.length === 0}
+        value={currentValue}
+        onChange={this.onChange}>
         {options.map(({key, value, label}) => (
           <option key={`route_select_${key}`} value={value}>
             {label}

--- a/src/components/filterbar/RouteInput.js
+++ b/src/components/filterbar/RouteInput.js
@@ -40,13 +40,17 @@ class RouteInput extends Component {
       };
     });
 
-    options.unshift({value: "", label: text("filterpanel.select_route")});
+    const hasRoutes = routes.length > 0;
+    options.unshift({
+      value: "",
+      label: hasRoutes ? text("filterpanel.select_route") : text("filterpanel.no_routes"),
+    });
     const currentValue = createRouteId(route);
 
     return (
       <Dropdown
         helpText="Select route"
-        disabled={routes.length === 0}
+        disabled={!hasRoutes}
         value={currentValue}
         onChange={this.onChange}>
         {options.map(({key, value, label}) => (

--- a/src/languages/ui/en.json
+++ b/src/languages/ui/en.json
@@ -12,6 +12,7 @@
   "filterpanel.filter_by_line": "Search line",
   "filterpanel.find_line_route": "Search line and route",
   "filterpanel.select_route": "Choose route",
+  "filterpanel.no_routes": "No routes available",
   "filterpanel.planned_start_time": "Planned start time",
   "filterpanel.real_start_time": "Observed start time",
   "filterpanel.journey.unrealized": "Unrealized",

--- a/src/languages/ui/fi.json
+++ b/src/languages/ui/fi.json
@@ -12,6 +12,7 @@
   "filterpanel.filter_by_line": "Hae linjaa",
   "filterpanel.find_line_route": "Hae linja ja reitti",
   "filterpanel.select_route": "Valitse reitti",
+  "filterpanel.no_routes": "TODO",
   "filterpanel.planned_start_time": "Suunniteltu lähtöaika",
   "filterpanel.real_start_time": "Toteutunut lähtöaika",
   "filterpanel.journey.unrealized": "Toteutumaton",

--- a/src/languages/ui/fi.json
+++ b/src/languages/ui/fi.json
@@ -12,7 +12,7 @@
   "filterpanel.filter_by_line": "Hae linjaa",
   "filterpanel.find_line_route": "Hae linja ja reitti",
   "filterpanel.select_route": "Valitse reitti",
-  "filterpanel.no_routes": "TODO",
+  "filterpanel.no_routes": "Reittejä ei löydetty",
   "filterpanel.planned_start_time": "Suunniteltu lähtöaika",
   "filterpanel.real_start_time": "Toteutunut lähtöaika",
   "filterpanel.journey.unrealized": "Toteutumaton",

--- a/src/languages/ui/se.json
+++ b/src/languages/ui/se.json
@@ -12,7 +12,7 @@
   "filterpanel.filter_by_line": "Sök linjer",
   "filterpanel.find_line_route": "Sök linje och rutt",
   "filterpanel.select_route": "Välj rutt",
-  "filterpanel.no_routes": "TODO",
+  "filterpanel.no_routes": "Inga rutter hittade",
   "filterpanel.planned_start_time": "Planerad starttid",
   "filterpanel.real_start_time": "Realiserad starttid",
   "filterpanel.journey.unrealized": "Ogenomförd",

--- a/src/languages/ui/se.json
+++ b/src/languages/ui/se.json
@@ -12,6 +12,7 @@
   "filterpanel.filter_by_line": "Sök linjer",
   "filterpanel.find_line_route": "Sök linje och rutt",
   "filterpanel.select_route": "Välj rutt",
+  "filterpanel.no_routes": "TODO",
   "filterpanel.planned_start_time": "Planerad starttid",
   "filterpanel.real_start_time": "Realiserad starttid",
   "filterpanel.journey.unrealized": "Ogenomförd",


### PR DESCRIPTION
Fixes #275
Note:
- The Finnish and Swedish translations for "No routes available" should still be filled in.
- Maybe `filterpanel.routes.select_route` and `filterpanel.routes.no_routes` or `filterpanel.routes.no_data` would be semantically better than `filterpanel.no_routes`

<img width="392" alt="Screenshot 2019-04-04 at 23 16 54" src="https://user-images.githubusercontent.com/11543641/55585932-7ab15700-5730-11e9-9384-a8af4db07e44.png">
