### PR TITLE
Timetable filters

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -828,7 +828,7 @@
     jquery "~3.2"
     lodash "~4.17"
 
-"@hot-loader/react-dom@^16.8.6", "@hot-loader/react-dom@npm:@hot-loader/react-dom", "react-dom@npm:@hot-loader/react-dom":
+"@hot-loader/react-dom@npm:@hot-loader/react-dom", "react-dom@npm:@hot-loader/react-dom":
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.6.tgz#7923ba27db1563a7cc48d4e0b2879a140df461ea"
   integrity sha512-+JHIYh33FVglJYZAUtRjfT5qZoT2mueJGNzU5weS2CVw26BgbxGKSujlJhO85BaRbg8sqNWyW1hYBILgK3ZCgA==


### PR DESCRIPTION
Fixes #300.

- Change the "clear" button to an "apply" button that applies the input values as departure filters. The previous solution with a debounced value was not working.
- After applying the button changes to a "clear" button to enable easy resetting of the filters. When the user changes the inputs again, the button becomes an apply button.

On the server (not in this PR):
- Properly match the route filter value and departures' routeId value.