### PR TITLE
Fix stop render performance

### DIFF
--- a/src/components/filterbar/StopInput.js
+++ b/src/components/filterbar/StopInput.js
@@ -75,7 +75,7 @@ export default observer(({date, stops, onSelect, stop, loading}) => {
       getValue={getSuggestionValue}
       highlightFirstSuggestion={true}
       renderSuggestion={renderSuggestionFn}
-      suggestions={options}
+      suggestions={options.slice(0, 50)}
       renderSuggestionsContainer={renderSuggestionsContainer(loading)}
       onSuggestionsFetchRequested={onSearch}
     />


### PR DESCRIPTION
Limits the stop suggestion list to 50 items as the server now returns all stops. Fixes #345.