### PR TITLE
refactor(mapstyle): Update font stack source url

### DIFF
--- a/src/simple-style.json
+++ b/src/simple-style.json
@@ -56,7 +56,7 @@
     }
   },
   "sprite": "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/sprite",
-  "glyphs": "https://static.hsl.fi/mapfonts/{fontstack}/{range}.pbf",
+  "glyphs": "https://static.hsldev.com/mapfonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",


### PR DESCRIPTION
static.hsl.fi is deprecating soon. Update to static.hsldev.com.