### PR TITLE
Events on map

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -185,6 +185,8 @@ type JourneyCancellationEvent {
 
 type JourneyEvent {
   id: ID!
+  lat: Float
+  lng: Float
   recordedAt: DateTime!
   recordedAtUnix: Int!
   recordedTime: Time!
@@ -200,6 +202,8 @@ type JourneyStopEvent {
   isNextDay: Boolean
   isOrigin: Boolean
   isTimingStop: Boolean!
+  lat: Float
+  lng: Float
   nextStopId: String!
   plannedDate: Date
   plannedDateTime: DateTime

--- a/src/components/map/DivIcon.js
+++ b/src/components/map/DivIcon.js
@@ -28,12 +28,17 @@ class DivIcon extends MapLayer {
       icon: leafletDivIcon,
     });
 
-    setTimeout(() => {
-      this.setState((prev) => (prev.icon !== icon ? {icon} : null));
-    }, 1);
-
     this.contextValue = {...props.leaflet, popupContainer: this.leafletElement};
     return this.leafletElement;
+  }
+
+  componentDidMount() {
+    super.componentDidMount();
+    const {icon} = this.props;
+
+    if (icon) {
+      this.setState((prev) => (prev.icon !== icon ? {icon} : null));
+    }
   }
 
   updateLeafletElement(fromProps, toProps) {

--- a/src/components/map/DivIcon.js
+++ b/src/components/map/DivIcon.js
@@ -1,29 +1,35 @@
 // Stolen from https://github.com/jgimbel/react-leaflet-div-icon/blob/master/div-icon.js
 import React from "react";
-import {render} from "react-dom";
+import {createPortal} from "react-dom";
 import {DivIcon as LeafletDivIcon, Marker as LeafletMarker} from "leaflet";
 import PropTypes from "prop-types";
 import {withLeaflet, MapLayer, LeafletProvider} from "react-leaflet";
+import {observer} from "mobx-react";
 
 @withLeaflet
+@observer
 class DivIcon extends MapLayer {
   static propTypes = {
     opacity: PropTypes.number,
     zIndexOffset: PropTypes.number,
   };
 
+  state = {
+    icon: null,
+  };
+
   // See https://github.com/PaulLeCam/react-leaflet/issues/275
   createLeafletElement(newProps) {
     const {icon, position, className, html = "", iconSize, pane, ...props} = newProps;
-    this.icon = new LeafletDivIcon({className, html, iconSize});
+    const leafletDivIcon = new LeafletDivIcon({className, html, iconSize});
 
     this.leafletElement = new LeafletMarker(position, {
       ...this.getOptions({...props, pane}),
-      icon: this.icon,
+      icon: leafletDivIcon,
     });
 
     setTimeout(() => {
-      this.renderComponent(newProps);
+      this.setState((prev) => (prev.icon !== icon ? {icon} : null));
     }, 1);
 
     this.contextValue = {...props.leaflet, popupContainer: this.leafletElement};
@@ -48,22 +54,28 @@ class DivIcon extends MapLayer {
       }
     }
 
-    this.renderComponent(toProps);
-  }
-
-  renderComponent(props) {
-    const container = this.leafletElement._icon;
-    const component = props.icon;
-
-    if (container) {
-      render(component, container);
-    }
+    this.setState((prev) => (prev.icon !== toProps.icon ? {icon: toProps.icon} : null));
   }
 
   render() {
     const {children} = this.props;
-    return children == null || this.contextValue == null ? null : (
-      <LeafletProvider value={this.contextValue}>{children}</LeafletProvider>
+    const {icon} = this.state;
+    const portalContainer = this.leafletElement._icon;
+
+    const context =
+      !children || !this.contextValue ? null : (
+        <LeafletProvider value={this.contextValue}>{children}</LeafletProvider>
+      );
+
+    if (!portalContainer && !context) {
+      return null;
+    }
+
+    return (
+      <>
+        {portalContainer && createPortal(icon, portalContainer)}
+        {context}
+      </>
     );
   }
 }

--- a/src/components/map/JourneyEventsLayer.js
+++ b/src/components/map/JourneyEventsLayer.js
@@ -14,8 +14,8 @@ const decorate = flow(
 const IconStyle = createGlobalStyle`
   .event-icon {
     text-indent: 0;
-    width: 12px;
-    height: 12px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     background: var(--light-blue);
     line-height: 1;
@@ -23,20 +23,21 @@ const IconStyle = createGlobalStyle`
     transition: transform 0.2s ease-out;
     
     &:hover {
-      transform: scale(1.15);
+      transform: scale(1.2);
     }
     
     span {
-      font-size: 11px;
+      font-size: 9px;
       font-weight: bold;
       position: absolute;
-      top: 1px;
-      left: 16px;
+      top: 0;
+      left: 11px;
+      color: var(--grey);
       
       &.left {
         left: auto;
         text-align: right;
-        right: 16px;
+        right: 11px;
       }
     }
   }
@@ -80,7 +81,7 @@ const JourneyEventsLayer = decorate(({journey = null, state}) => {
     currentGroup.positions.push(point);
     currentGroup.events.push(event);
     currentGroup.id = currentGroup.events
-      .map(({id}) => id)
+      .map(({id}, idx) => id + idx)
       .sort()
       .join("_");
 

--- a/src/components/map/JourneyEventsLayer.js
+++ b/src/components/map/JourneyEventsLayer.js
@@ -19,6 +19,7 @@ const IconStyle = createGlobalStyle`
     border-radius: 50%;
     background: var(--light-blue);
     position: relative;
+    line-height: 1;
     
     span {
       font-size: 11px;

--- a/src/components/map/JourneyEventsLayer.js
+++ b/src/components/map/JourneyEventsLayer.js
@@ -14,28 +14,30 @@ const decorate = flow(
 const IconStyle = createGlobalStyle`
   .event-icon {
     text-indent: 0;
-    width: 15px;
-    height: 15px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     background: var(--light-blue);
     line-height: 1;
     position: relative;
+    transition: transform 0.2s ease-out;
+    
+    &:hover {
+      transform: scale(1.15);
+    }
     
     span {
       font-size: 11px;
       font-weight: bold;
-      text-align: center;
-      margin-top: 12px;
       position: absolute;
-      top: 5px;
-      left: calc(50% - 7.5px);
-      margin-left: -3.5px;
-    }
-  }
-  
-  .event-icon.offsetIcon {
-    span {
-      top: 20px;
+      top: 1px;
+      left: 16px;
+      
+      &.left {
+        left: auto;
+        text-align: right;
+        right: 16px;
+      }
     }
   }
 `;
@@ -89,8 +91,12 @@ const JourneyEventsLayer = decorate(({journey = null, state}) => {
   return (
     <>
       <IconStyle />
-      {Array.from(eventGroups.values()).map((eventGroup) => (
-        <JourneyMapEvent key={eventGroup.id} eventGroup={eventGroup} />
+      {Array.from(eventGroups.values()).map((eventGroup, i) => (
+        <JourneyMapEvent
+          key={`event_group_${eventGroup.id}`}
+          eventGroup={eventGroup}
+          rightText={i % 2 === 0}
+        />
       ))}
     </>
   );

--- a/src/components/map/JourneyEventsLayer.js
+++ b/src/components/map/JourneyEventsLayer.js
@@ -18,8 +18,8 @@ const IconStyle = createGlobalStyle`
     height: 15px;
     border-radius: 50%;
     background: var(--light-blue);
-    position: relative;
     line-height: 1;
+    position: relative;
     
     span {
       font-size: 11px;

--- a/src/components/map/JourneyEventsLayer.js
+++ b/src/components/map/JourneyEventsLayer.js
@@ -1,0 +1,98 @@
+import React, {useMemo} from "react";
+import flow from "lodash/flow";
+import {observer} from "mobx-react-lite";
+import {inject} from "../../helpers/inject";
+import JourneyMapEvent from "./JourneyMapEvent";
+import {createGlobalStyle} from "styled-components";
+import {latLng} from "leaflet";
+
+const decorate = flow(
+  observer,
+  inject("state")
+);
+
+const IconStyle = createGlobalStyle`
+  .event-icon {
+    text-indent: 0;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background: var(--light-blue);
+    position: relative;
+    
+    span {
+      font-size: 11px;
+      font-weight: bold;
+      text-align: center;
+      margin-top: 12px;
+      position: absolute;
+      top: 5px;
+      left: calc(50% - 7.5px);
+      margin-left: -3.5px;
+    }
+  }
+  
+  .event-icon.offsetIcon {
+    span {
+      top: 20px;
+    }
+  }
+`;
+
+const JourneyEventsLayer = decorate(({journey = null, state}) => {
+  const nonStopEvents = useMemo(() => {
+    if (!journey || !journey.events || journey.events.length === 0) {
+      return [];
+    }
+
+    return journey.events.filter(
+      (evt) => evt.__typename !== "JourneyStopEvent" && !!evt.lat && !!evt.lng
+    );
+  }, [journey]);
+
+  const visibleEvents = nonStopEvents.filter(
+    (evt) => !!state.journeyEventFilters[evt.type]
+  );
+
+  const eventGroups = visibleEvents.reduce((proximityGroups, event) => {
+    const point = latLng([event.lat, event.lng]);
+    let currentArea = point.toBounds(5);
+
+    const initialGroup = {
+      id: "empty_group",
+      positions: [],
+      types: [],
+      events: [],
+    };
+
+    for (const area of proximityGroups.keys()) {
+      if (area.contains(point)) {
+        currentArea = area;
+        break;
+      }
+    }
+
+    const currentGroup = proximityGroups.get(currentArea) || initialGroup;
+
+    currentGroup.positions.push(point);
+    currentGroup.events.push(event);
+    currentGroup.id = currentGroup.events
+      .map(({id}) => id)
+      .sort()
+      .join("_");
+
+    proximityGroups.set(currentArea, currentGroup);
+    return proximityGroups;
+  }, new Map());
+
+  return (
+    <>
+      <IconStyle />
+      {Array.from(eventGroups.values()).map((eventGroup) => (
+        <JourneyMapEvent key={eventGroup.id} eventGroup={eventGroup} />
+      ))}
+    </>
+  );
+});
+
+export default JourneyEventsLayer;

--- a/src/components/map/JourneyMapEvent.js
+++ b/src/components/map/JourneyMapEvent.js
@@ -18,8 +18,7 @@ const JourneyMapEvent = decorate(({eventGroup}) => {
     .join("<br />")}</span>`;
 
   const icon = divIcon({
-    html: eventTypesContent,
-    className: `event-icon`,
+    html: `<div class="event-icon">${eventTypesContent}</div>`,
     iconSize: [15, 15],
   });
 

--- a/src/components/map/JourneyMapEvent.js
+++ b/src/components/map/JourneyMapEvent.js
@@ -10,16 +10,21 @@ import {TIMEZONE} from "../../constants";
 
 const decorate = flow(observer);
 
-const JourneyMapEvent = decorate(({eventGroup}) => {
+const stopEvents = ["DEP", "PDE", "PAS", "ARR", "ARS", "DUE", "WAIT"];
+
+const JourneyMapEvent = decorate(({eventGroup, rightText = true}) => {
+  const isStopEvent = eventGroup.events.some(({type}) => stopEvents.includes(type));
   const orderedEvents = orderBy(eventGroup.events, "recordedAtUnix");
 
-  const eventTypesContent = `<span>${orderedEvents
-    .map(({type}) => type)
-    .join("<br />")}</span>`;
+  const eventTypesContent = `<span class="${
+    rightText ? "right" : "left"
+  }">${orderedEvents.map(({type}) => type).join("<br />")}</span>`;
+
+  const color = isStopEvent ? "var(--light-blue)" : "var(--dark-blue)";
 
   const icon = divIcon({
-    html: `<div class="event-icon">${eventTypesContent}</div>`,
-    iconSize: [15, 15],
+    html: `<div class="event-icon" style="background-color: ${color}">${eventTypesContent}</div>`,
+    iconSize: [12, 12],
   });
 
   const center =
@@ -29,7 +34,10 @@ const JourneyMapEvent = decorate(({eventGroup}) => {
 
   return (
     <Marker icon={icon} position={center} pane="hfp-events">
-      <Tooltip>
+      <Tooltip
+        direction={rightText ? "left" : "right"}
+        interactive={false}
+        offset={[rightText ? -10 : 10, 0]}>
         {orderedEvents.map((event) => (
           <div key={`${event.type}_${event.recordedAtUnix}`}>
             <span style={{marginRight: "0.5rem"}}>

--- a/src/components/map/JourneyMapEvent.js
+++ b/src/components/map/JourneyMapEvent.js
@@ -6,14 +6,12 @@ import {Marker, Tooltip} from "react-leaflet";
 import {divIcon, latLngBounds} from "leaflet";
 import {text} from "../../helpers/text";
 import moment from "moment-timezone";
-import {TIMEZONE} from "../../constants";
+import {TIMEZONE, STOP_EVENTS} from "../../constants";
 
 const decorate = flow(observer);
 
-const stopEvents = ["DEP", "PDE", "PAS", "ARR", "ARS", "DUE", "WAIT"];
-
 const JourneyMapEvent = decorate(({eventGroup, rightText = true}) => {
-  const isStopEvent = eventGroup.events.some(({type}) => stopEvents.includes(type));
+  const isStopEvent = eventGroup.events.some(({type}) => STOP_EVENTS.includes(type));
   const orderedEvents = orderBy(eventGroup.events, "recordedAtUnix");
 
   const eventTypesContent = `<span class="${
@@ -24,7 +22,7 @@ const JourneyMapEvent = decorate(({eventGroup, rightText = true}) => {
 
   const icon = divIcon({
     html: `<div class="event-icon" style="background-color: ${color}">${eventTypesContent}</div>`,
-    iconSize: [12, 12],
+    iconSize: [8, 8],
   });
 
   const center =
@@ -38,8 +36,8 @@ const JourneyMapEvent = decorate(({eventGroup, rightText = true}) => {
         direction={rightText ? "left" : "right"}
         interactive={false}
         offset={[rightText ? -10 : 10, 0]}>
-        {orderedEvents.map((event) => (
-          <div key={`${event.type}_${event.recordedAtUnix}`}>
+        {orderedEvents.map((event, idx) => (
+          <div key={`${event.type}_${event.recordedAtUnix}_${idx}`}>
             <span style={{marginRight: "0.5rem"}}>
               {moment.tz(event.recordedAt, TIMEZONE).format("HH:mm:ss")}
             </span>

--- a/src/components/map/JourneyMapEvent.js
+++ b/src/components/map/JourneyMapEvent.js
@@ -1,0 +1,58 @@
+import flow from "lodash/flow";
+import orderBy from "lodash/orderBy";
+import {observer} from "mobx-react-lite";
+import React from "react";
+import {Marker, Tooltip} from "react-leaflet";
+import {divIcon, latLngBounds} from "leaflet";
+import {text} from "../../helpers/text";
+import moment from "moment-timezone";
+import {TIMEZONE} from "../../constants";
+
+const decorate = flow(observer);
+
+const JourneyMapEvent = decorate(({eventGroup}) => {
+  const orderedEvents = orderBy(eventGroup.events, "recordedAtUnix");
+
+  const eventTypesContent = `<span>${orderedEvents
+    .map(({type}) => type)
+    .join("<br />")}</span>`;
+
+  const icon = divIcon({
+    html: eventTypesContent,
+    className: `event-icon`,
+    iconSize: [15, 15],
+  });
+
+  const center =
+    eventGroup.positions.length === 1
+      ? eventGroup.positions[0]
+      : latLngBounds(eventGroup.positions).getCenter();
+
+  return (
+    <Marker icon={icon} position={center} pane="hfp-events">
+      <Tooltip>
+        <div
+          style={{
+            width: "100%",
+            marginBottom: "0.25rem",
+            paddingBottom: "0.25rem",
+            borderBottom: "1px solid var(--lighter-grey)",
+          }}>
+          {moment.tz(orderedEvents[0].recordedAt, TIMEZONE).format("DD.MM.Y")}
+        </div>
+        {orderedEvents.map((event) => (
+          <div key={`${event.type}_${event.recordedAtUnix}`}>
+            <span style={{marginRight: "0.5rem"}}>
+              {moment.tz(event.recordedAt, TIMEZONE).format("HH:mm:ss")}
+            </span>
+            <strong
+              dangerouslySetInnerHTML={{__html: text(`journey.event.${event.type}`)}}
+            />
+          </div>
+        ))}
+      </Tooltip>
+    </Marker>
+  );
+});
+
+export default JourneyMapEvent;

--- a/src/components/map/JourneyMapEvent.js
+++ b/src/components/map/JourneyMapEvent.js
@@ -31,15 +31,6 @@ const JourneyMapEvent = decorate(({eventGroup}) => {
   return (
     <Marker icon={icon} position={center} pane="hfp-events">
       <Tooltip>
-        <div
-          style={{
-            width: "100%",
-            marginBottom: "0.25rem",
-            paddingBottom: "0.25rem",
-            borderBottom: "1px solid var(--lighter-grey)",
-          }}>
-          {moment.tz(orderedEvents[0].recordedAt, TIMEZONE).format("DD.MM.Y")}
-        </div>
         {orderedEvents.map((event) => (
           <div key={`${event.type}_${event.recordedAtUnix}`}>
             <span style={{marginRight: "0.5rem"}}>

--- a/src/components/map/JourneyStopsLayer.js
+++ b/src/components/map/JourneyStopsLayer.js
@@ -15,17 +15,11 @@ const decorate = flow(
 );
 
 const JourneyStopsLayer = decorate(
-  ({
-    state: {date, stop: selectedStop, highlightedStop, selectedJourney},
-    onViewLocation,
-    showRadius,
-    journey = null,
-  }) => {
+  ({state: {date, selectedJourney}, onViewLocation, showRadius, journey = null}) => {
     if (journey && journey.events) {
-      const stopEvents = journey.events.filter((evt) => {
-        const useDEP = evt.isTimingStop || evt.isOrigin;
-        return ["ARS", "PLANNED", useDEP ? "DEP" : "PDE"].includes(evt.type);
-      });
+      const stopEvents = journey.events.filter(
+        (evt) => evt.__typename === "JourneyStopEvent"
+      );
 
       const stopGroups = orderBy(
         Object.values(groupBy(stopEvents, "stopId")),

--- a/src/components/map/LeafletMap.js
+++ b/src/components/map/LeafletMap.js
@@ -177,6 +177,8 @@ class LeafletMap extends Component {
           <Pane name="selected-stop-radius" style={{zIndex: 445}} />
           <Pane name="event-hover" style={{zIndex: 450}} />
           <Pane name="stops" style={{zIndex: 475}} />
+          <Pane name="hfp-events" style={{zIndex: 480}} />
+          <Pane name="hfp-events-2" style={{zIndex: 485}} />
           <Pane name="hfp-markers" style={{zIndex: 500}} />
           <Pane name="hfp-markers-primary" style={{zIndex: 550}} />
           <Pane name="popups" style={{zIndex: 600}} />

--- a/src/components/map/MapContent.js
+++ b/src/components/map/MapContent.js
@@ -19,6 +19,7 @@ import JourneyStopsLayer from "./JourneyStopsLayer";
 import {WeatherWidget, JourneyWeatherWidget} from "./WeatherWidget";
 import get from "lodash/get";
 import UnsignedEventsLayer from "./UnsignedEventsLayer";
+import JourneyEventsLayer from "./JourneyEventsLayer";
 
 const decorate = flow(
   observer,
@@ -118,6 +119,10 @@ const MapContent = decorate(
                     showRadius={showStopRadius}
                     onViewLocation={viewLocation}
                     key={`journey_stops_${journey.id}`}
+                    journey={journey}
+                  />,
+                  <JourneyEventsLayer
+                    key={`journey_map_events_${journey.id}`}
                     journey={journey}
                   />,
                   currentPosition ? (

--- a/src/components/sidepanel/journeyDetails/JourneyEvents.js
+++ b/src/components/sidepanel/journeyDetails/JourneyEvents.js
@@ -60,7 +60,7 @@ const JourneyEvents = decorate(
       (nextState) => {
         Journey.setJourneyEventFilter(nextState);
       },
-      [Journey, state.journeyEvents]
+      [Journey, state.journeyEventFilters]
     );
 
     const onClickTime = useCallback(
@@ -92,9 +92,9 @@ const JourneyEvents = decorate(
 
     return (
       <EventsListWrapper>
-        <EventFilters onChange={onFilterChange} filterState={state.journeyEvents} />
+        <EventFilters onChange={onFilterChange} filterState={state.journeyEventFilters} />
         <EventsList>
-          {uniqBy(events, "id")
+          {events
             .filter((event, index, arr) => {
               const eventsOfType = arr.filter((evt) => evt.type === event.type);
               // The origin stop is the PLANNED origin stop, not necessarily always
@@ -132,7 +132,7 @@ const JourneyEvents = decorate(
                 types.push("TERMINAL_ARS");
               }
 
-              return types.some((type) => state.journeyEvents[type]);
+              return types.some((type) => state.journeyEventFilters[type]);
             })
             .map((event, index, arr) => {
               let Component = JourneyEvent;

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,3 +5,4 @@ export const AUTH_STATE_STORAGE_KEY = "pre_auth_state";
 export const TIME_SLIDER_MAX = 102600; // 28:30:00
 export const TIME_SLIDER_MIN = 0; // 00:00:00
 export const TIME_SLIDER_DEFAULT_MIN = 16200; // 04:30
+export const STOP_EVENTS = ["DEP", "PDE", "PAS", "ARR", "ARS", "DUE", "WAIT"];

--- a/src/queries/JourneyQuery.js
+++ b/src/queries/JourneyQuery.js
@@ -108,6 +108,8 @@ export const journeyQuery = gql`
           type
           isOrigin
           isTimingStop
+          lat
+          lng
           stop {
             id
             isTimingStop
@@ -158,6 +160,8 @@ export const journeyQuery = gql`
           recordedTime
           type
           stopId
+          lat
+          lng
         }
       }
       departure {

--- a/src/stores/JourneyStore.js
+++ b/src/stores/JourneyStore.js
@@ -15,7 +15,7 @@ import {intval} from "../helpers/isWithinRange";
 export default (state) => {
   extendObservable(state, {
     selectedJourney: null,
-    journeyEvents: {},
+    journeyEventFilters: {},
   });
 
   const filterActions = FilterActions(state);

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -73,17 +73,17 @@ export default (state) => {
   });
 
   const setJourneyEventFilter = action((events, init = false) => {
-    if (Object.keys(state.journeyEvents).length === 0 && init) {
+    if (Object.keys(state.journeyEventFilters).length === 0 && init) {
       // Init the filter state with events from the component if the filterState is empty.
-      state.journeyEvents = events;
+      state.journeyEventFilters = events;
     } else if (init) {
       // If a new init comes in when we have filter state, add any possible new filter items
       // to the state by merging. Merge the current state last to retain the current state.
-      state.journeyEvents = merge({}, events, state.journeyEvents);
+      state.journeyEventFilters = merge({}, events, state.journeyEventFilters);
     } else if (!init) {
       if (typeof events.ALL !== "undefined") {
         // Set all filters to the value of events.ALL if present
-        Object.keys(state.journeyEvents).map((key) => {
+        Object.keys(state.journeyEventFilters).map((key) => {
           // Set the default configuration if deselecting ALL. For others, set the value of ALL.
           const setValue =
             !events.ALL &&
@@ -91,14 +91,14 @@ export default (state) => {
               ? true
               : events.ALL;
 
-          state.journeyEvents[key] = setValue;
+          state.journeyEventFilters[key] = setValue;
         });
       } else {
         // Set the new filter state from the 'events' argument.
-        Object.keys(events).map((key) => (state.journeyEvents[key] = events[key]));
+        Object.keys(events).map((key) => (state.journeyEventFilters[key] = events[key]));
 
         // If some filters are turned off, also set the all switch to off. Either set it to on.
-        state.journeyEvents.ALL = !Object.values(state.journeyEvents).some(
+        state.journeyEventFilters.ALL = !Object.values(state.journeyEventFilters).some(
           (val) => val === false
         );
       }


### PR DESCRIPTION
- Show events on the map with a small blue marker
- Only non-stop events with lat/lng position are shown on the map
- Events on the map are filtered with the same filters as events in the journey sidebar. Map events will initially not be visible, make sure to select the events you want with the filters.
- Tooltips with the longer event description (from translations) and timestamp
- Marker grouping (with an area of 5m) so that events that happened at the same place don't overlap too badly. All grouped event info is shown in the tooltip.

Fixes #409. Testable in dev.