### PR TITLE
Stops hover

### DIFF
--- a/src/components/map/RouteStop.js
+++ b/src/components/map/RouteStop.js
@@ -333,10 +333,10 @@ class RouteStop extends React.Component {
 
     stopTooltip = (
       <Tooltip key={`stop${stopId}_tooltip`}>
-        <StopHeading>
-          {stopName && <strong>{stopName}</strong>} {stopId}{" "}
-          {stopShortId && `(${stopShortId})`}
-        </StopHeading>
+        <div>
+          <strong>{stop.shortId.replace(/\s*/g, "")}</strong> {stop.stopId}
+        </div>
+        <div style={{fontSize: "1rem"}}>{stop.name}</div>
         {!isPlanned && !doorDidOpen && (
           <TooltipParagraph>
             <Text>map.stops.doors_not_open</Text>

--- a/src/components/map/RouteStop.js
+++ b/src/components/map/RouteStop.js
@@ -77,11 +77,15 @@ class RouteStop extends React.Component {
     const isTerminal = firstTerminal || lastTerminal;
 
     let stopTooltip = (
-      <Tooltip key={`stop${stopId}_tooltip`}>
-        <StopHeading>
-          <strong>{get(stop, "name", "")}</strong> {stopId} (
-          {get(stop, "shortId", "").replace(/ /g, "")})
-        </StopHeading>
+      <Tooltip
+        key={`stop${stopId}_tooltip`}
+        offset={[15, 0]}
+        interactive={false}
+        direction="right">
+        <div>
+          <strong>{stop.shortId.replace(/\s*/g, "")}</strong> {stop.stopId}
+        </div>
+        <div style={{fontSize: "1rem"}}>{stop.name}</div>
       </Tooltip>
     );
 

--- a/src/components/map/RouteStopsLayer.js
+++ b/src/components/map/RouteStopsLayer.js
@@ -31,6 +31,7 @@ const RouteStopsLayer = decorate(
                 lastTerminal={isLast}
                 selectedJourney={selectedJourney}
                 firstStop={arr[0]}
+                stopId={stop.stopId}
                 stop={stop}
                 date={date}
                 onViewLocation={onViewLocation}

--- a/src/components/map/StopMarker.js
+++ b/src/components/map/StopMarker.js
@@ -13,6 +13,7 @@ import DivIcon from "./DivIcon";
 import AlertIcons from "../AlertIcons";
 import {getAlertsInEffect} from "../../helpers/getAlertsInEffect";
 import TimingStop from "../../icons/TimingStop";
+import {Tooltip} from "react-leaflet";
 
 const decorate = flow(
   observer,
@@ -164,29 +165,39 @@ const StopMarker = decorate(
     const stopAlerts =
       alerts && alerts.length !== 0 ? alerts : getAlertsInEffect(stop, state.date);
 
+    const markerIcon = (
+      <IconWrapper>
+        <StopMarkerCircle
+          thickBorder={isTerminal}
+          isSelected={isSelected}
+          isHighlighted={isHighlighted}
+          isTimingStop={stopIsTimingStop}
+          dashed={dashedBorder}
+          big={!!(iconChildren || isSelected || isTerminal || stopIsTimingStop)}
+          color={stopColor}>
+          {stopIsTimingStop ? <TimingStop fill={stopColor} /> : iconChildren}
+        </StopMarkerCircle>
+        {stopAlerts.length !== 0 && (
+          <MarkerIcons iconSize="0.875rem" alerts={stopAlerts} />
+        )}
+      </IconWrapper>
+    );
+
     const markerElement = (
       <DivIcon
         ref={markerRef}
         pane="stops"
         position={markerPosition}
-        icon={
-          <IconWrapper>
-            <StopMarkerCircle
-              thickBorder={isTerminal}
-              isSelected={isSelected}
-              isHighlighted={isHighlighted}
-              isTimingStop={stopIsTimingStop}
-              dashed={dashedBorder}
-              big={!!(iconChildren || isSelected || isTerminal || stopIsTimingStop)}
-              color={stopColor}>
-              {stopIsTimingStop ? <TimingStop fill={stopColor} /> : iconChildren}
-            </StopMarkerCircle>
-            {stopAlerts.length !== 0 && (
-              <MarkerIcons iconSize="0.875rem" alerts={stopAlerts} />
-            )}
-          </IconWrapper>
-        }
+        icon={markerIcon}
         onClick={selectStop}>
+        {stop && (
+          <Tooltip offset={[15, 0]} interactive={false} direction="right">
+            <div>
+              <strong>{stop.shortId.replace(/\s*/g, "")}</strong> {stop.stopId}
+            </div>
+            <div style={{fontSize: "1rem"}}>{stop.name}</div>
+          </Tooltip>
+        )}
         {popupElement}
       </DivIcon>
     );


### PR DESCRIPTION
- Show tooltip when hovering over a stop.
- Unify stop name and ID style in tooltips.

Fixes #359.