### PR TITLE
Correct route selection

### DIFF
--- a/src/components/sidepanel/SidePanel.js
+++ b/src/components/sidepanel/SidePanel.js
@@ -138,7 +138,7 @@ const SidePanel = decorate((props) => {
     },
   } = props;
 
-  const hasRoute = (!!stateRoute || !!route) && !!(stateRoute || route).routeId;
+  const hasRoute = route && route.routeId;
   // Figure out which tab is suggested. It will not be outright selected, but
   // if it appears and nothing else is selected then it will be.
   let suggestedTab = "";

--- a/src/queries/RouteDeparturesQuery.js
+++ b/src/queries/RouteDeparturesQuery.js
@@ -117,6 +117,7 @@ const RouteDeparturesQuery = observer(({children, route, date, skip}) => {
 
   const {routeId, direction, originStopId} = route;
   const shouldSkip = skip || !route || !routeId || !direction || !originStopId;
+
   const queryVars = {
     routeId: routeId,
     direction: parseInt(direction, 10),

--- a/src/stores/journeyActions.js
+++ b/src/stores/journeyActions.js
@@ -52,7 +52,11 @@ export default (state) => {
     } else if (journeyItem) {
       const oldVehicle = get(state, "vehicle", "");
       state.selectedJourney = getJourneyObject(journeyItem);
-      filters.setRoute(journeyItem);
+
+      filters.setRoute({
+        routeId: get(journeyItem, "routeId", ""),
+        direction: get(journeyItem, "direction", ""),
+      });
 
       if (journeyItem.uniqueVehicleId !== oldVehicle) {
         filters.setVehicle(journeyItem.uniqueVehicleId);


### PR DESCRIPTION
When the route is set from selecting a journey, the wrong data (namely, the origin stop ID) was in some cases set in the route state, leading to empty or false route departures being fetched. This PR fixes #406 by only setting the routeId and direction and letting the withROute HOC handle the rest.