### PR TITLE
Fix tabs

### DIFF
--- a/cypress/integration/route.spec.js
+++ b/cypress/integration/route.spec.js
@@ -50,7 +50,7 @@ describe("Route smoke tests", () => {
 
     cy.waitUntilLoadingFinishes();
 
-    cy.getTestElement("sidebar-tab-journeys_by_week").click();
+    cy.getTestElement("sidebar-tab-week-journeys").click();
     cy.getTestElement("journeys-by-week-list").should("exist");
 
     cy.getTestElement("weekly-departure-time").should("have.length.least", 2);
@@ -71,7 +71,7 @@ describe("Route smoke tests", () => {
 
     cy.waitUntilLoadingFinishes();
 
-    cy.getTestElement("sidebar-tab-journeys_by_week").click();
+    cy.getTestElement("sidebar-tab-week-journeys").click();
     cy.getTestElement("journeys-by-week-list").should("exist");
 
     cy.getTestElement("weekly-departure-time")

--- a/src/__tests__/integration/SelectRoute.test.js
+++ b/src/__tests__/integration/SelectRoute.test.js
@@ -49,15 +49,23 @@ const routeDepartureMocks = [
 describe("Route selection and filtering", () => {
   let state = {};
   let setRouteMock = jest.fn();
+  let setTabMock = jest.fn();
 
   const createState = () => {
     state = observable({
+      sidePanelTab: "alerts",
       language: "fi",
       live: false,
       date,
       sidePanelVisible: true,
       route: {routeId: "", direction: "", originStopId: ""},
     });
+
+    setTabMock = jest.fn(
+      action((tab) => {
+        state.sidePanelTab = tab;
+      })
+    );
 
     setRouteMock = jest.fn(
       action((route) => {
@@ -70,7 +78,14 @@ describe("Route selection and filtering", () => {
   };
 
   const RenderContext = ({children}) => (
-    <MobxProviders state={state} actions={{UI: {}, Filters: {setRoute: setRouteMock}}}>
+    <MobxProviders
+      state={state}
+      actions={{
+        UI: {
+          setSidePanelTab: setTabMock,
+        },
+        Filters: {setRoute: setRouteMock},
+      }}>
       <MockedProvider addTypename={true} mocks={routeDepartureMocks}>
         {children}
       </MockedProvider>

--- a/src/__tests__/integration/SelectStop.test.js
+++ b/src/__tests__/integration/SelectStop.test.js
@@ -110,15 +110,23 @@ describe("Stop search and filtering", () => {
   let state = {};
   let setStopMock = jest.fn();
   let setTerminalMock = jest.fn();
+  let setTabMock = jest.fn();
 
   const createState = () => {
     state = observable({
+      sidePanelTab: "alerts",
       language: "fi",
       live: false,
       date,
       stop: "",
       route: {},
     });
+
+    setTabMock = jest.fn(
+      action((tab) => {
+        state.sidePanelTab = tab;
+      })
+    );
 
     setStopMock = jest.fn(
       action((stop) => {
@@ -137,10 +145,12 @@ describe("Stop search and filtering", () => {
     <MobxProviders
       state={state}
       actions={{
-        UI: {},
+        UI: {
+          setSidePanelTab: setTabMock,
+        },
         Filters: {
-          setStop: (stop) => setStopMock(stop),
-          setTerminal: (terminal) => setTerminalMock(terminal),
+          setStop: setStopMock,
+          setTerminal: setTerminalMock,
         },
       }}>
       <MockedProvider addTypename={true} mocks={stopRequestMocks}>

--- a/src/components/filterbar/RouteInput.js
+++ b/src/components/filterbar/RouteInput.js
@@ -9,8 +9,9 @@ import getTransportType from "../../helpers/getTransportType";
 import {parseLineNumber} from "../../helpers/parseLineNumber";
 import sortBy from "lodash/sortBy";
 import {text} from "../../helpers/text";
+import {SidePanelTabs} from "../../constants";
 
-const decorate = flow(observer, inject("Filters"));
+const decorate = flow(observer, inject("Filters", "UI"));
 
 const renderSuggestion = (date, routes) => (suggestion, {isHighlighted}) => {
   const route = getFullRoute(routes, suggestion);
@@ -160,7 +161,7 @@ export const getFullRoute = (routes, selectedRoute) => {
   return routes.find((r) => createRouteId(r) === routeId) || null;
 };
 
-const RouteInput = decorate(({state: {route, date}, Filters, routes}) => {
+const RouteInput = decorate(({state: {route, date}, Filters, UI, routes}) => {
   const [options, setOptions] = useState([]);
 
   const getValue = useCallback(
@@ -181,6 +182,7 @@ const RouteInput = decorate(({state: {route, date}, Filters, routes}) => {
 
       if (selectedRoute) {
         Filters.setRoute(selectedRoute);
+        UI.setSidePanelTab(SidePanelTabs.Journeys);
       }
     },
     [Filters, routes]

--- a/src/components/filterbar/StopSettings.js
+++ b/src/components/filterbar/StopSettings.js
@@ -15,14 +15,15 @@ import {allStopsQuery} from "../map/StopLayer";
 import {terminalsQuery} from "../map/TerminalLayer";
 import orderBy from "lodash/orderBy";
 import getTransportType from "../../helpers/getTransportType";
+import {SidePanelTabs} from "../../constants";
 
 const LoadingSpinner = styled(Loading)`
   margin: 0.5rem 0.5rem 0.5rem 1rem;
 `;
 
-const decorate = flow(observer, inject("Filters"));
+const decorate = flow(observer, inject("Filters", "UI"));
 
-const StopSettings = decorate(({Filters, state}) => {
+const StopSettings = decorate(({Filters, UI, state}) => {
   const {stop, terminal, date} = state;
 
   const {data: stopsData, loading} = useQueryData(
@@ -40,13 +41,20 @@ const StopSettings = decorate(({Filters, state}) => {
   const stops = stopsData || [];
   const terminals = terminalsData || [];
 
-  const onSelectOption = useCallback((item) => {
-    if (isStop(item)) {
-      Filters.setStop(item);
-    } else {
-      Filters.setTerminal(item);
-    }
-  }, []);
+  const onSelectOption = useCallback(
+    (item) => {
+      if (isStop(item)) {
+        Filters.setStop(item);
+      } else {
+        Filters.setTerminal(item);
+      }
+
+      if (item) {
+        UI.setSidePanelTab(SidePanelTabs.Timetables);
+      }
+    },
+    [Filters, UI]
+  );
 
   if (loading && stops.length === 0) {
     return <LoadingSpinner inline={true} />;

--- a/src/components/filterbar/VehicleSettings.js
+++ b/src/components/filterbar/VehicleSettings.js
@@ -11,6 +11,7 @@ import {inject} from "../../helpers/inject";
 import {SelectedOptionDisplay, SuggestionText} from "./SuggestionInput";
 import styled from "styled-components";
 import Loading from "../Loading";
+import {SidePanelTabs} from "../../constants";
 
 const LoadingSpinner = styled(Loading)`
   margin: 0.5rem 0.5rem 0.5rem 1rem;
@@ -23,10 +24,19 @@ const UnsignedEventsLoading = styled(Loading).attrs({inline: true, size: 20})`
   right: -10px;
 `;
 
-const decorate = flow(observer, inject("Filters"));
+const decorate = flow(observer, inject("Filters", "UI"));
 
-const VehicleSettings = decorate(({Filters, state}) => {
-  const onSelectVehicle = useCallback((value) => Filters.setVehicle(value), [Filters]);
+const VehicleSettings = decorate(({Filters, UI, state}) => {
+  const onSelectVehicle = useCallback(
+    (value) => {
+      Filters.setVehicle(value);
+
+      if (value) {
+        UI.setSidePanelTab(SidePanelTabs.Journeys);
+      }
+    },
+    [Filters, UI]
+  );
 
   const {vehicle = "", date, selectedJourney, unsignedEventsLoading} = state;
   const isDisabled = !!selectedJourney;

--- a/src/components/journeypanel/JourneyPanel.js
+++ b/src/components/journeypanel/JourneyPanel.js
@@ -1,4 +1,4 @@
-import React, {useMemo, useState, useCallback} from "react";
+import React, {useMemo, useState, useCallback, useEffect} from "react";
 import styled from "styled-components";
 import JourneyDetailsHeader from "./JourneyDetailsHeader";
 import {observer} from "mobx-react-lite";
@@ -61,15 +61,16 @@ const JourneyPanel = decorate(
       getUrlValue("details-tab", "journey-events")
     );
 
-    const onTabChange = useCallback(
-      (nextTab) => {
-        if (!loading) {
-          setCurrentTab(nextTab);
-          setUrlValue("details-tab", nextTab);
-        }
-      },
-      [loading]
-    );
+    const onTabChange = useCallback((nextTab) => {
+      setCurrentTab(nextTab);
+      setUrlValue("details-tab", nextTab);
+    }, []);
+
+    useEffect(() => {
+      if (selectedJourney && !loading) {
+        onTabChange("journey-events");
+      }
+    }, [selectedJourney, loading]);
 
     const journeyMode = get(route, "mode", "BUS");
     const journeyColor = get(transportColor, journeyMode, "var(--light-grey)");

--- a/src/components/journeypanel/JourneyPanel.js
+++ b/src/components/journeypanel/JourneyPanel.js
@@ -18,6 +18,7 @@ import {useJourneyHealth} from "../../hooks/useJourneyHealth";
 import JourneyHealthDetails from "./JourneyHealthDetails";
 import RouteStops from "./RouteStops";
 import {useDataDelay} from "../../hooks/useDataDelay";
+import {getUrlValue, setUrlValue} from "../../stores/UrlManager";
 
 const JourneyPanelWrapper = styled.div`
   height: 100%;
@@ -56,12 +57,15 @@ const JourneyPanel = decorate(
     route = null,
     loading = false,
   }) => {
-    const [currentTab, setCurrentTab] = useState("journey-events");
+    const [currentTab, setCurrentTab] = useState(
+      getUrlValue("details-tab", "journey-events")
+    );
 
     const onTabChange = useCallback(
       (nextTab) => {
         if (!loading) {
           setCurrentTab(nextTab);
+          setUrlValue("details-tab", nextTab);
         }
       },
       [loading]
@@ -105,9 +109,7 @@ const JourneyPanel = decorate(
             <JourneyInfo date={date} journey={journey} departure={originDeparture} />
             <Tabs
               testIdPrefix="journey"
-              urlValue="details-tab"
               onTabChange={onTabChange}
-              suggestedTab="journey-events"
               selectedTab={currentTab}>
               {journeyEvents.length !== 0 && (
                 <JourneyEvents

--- a/src/components/journeypanel/RouteStops.js
+++ b/src/components/journeypanel/RouteStops.js
@@ -4,6 +4,7 @@ import {observer} from "mobx-react-lite";
 import flow from "lodash/flow";
 import RouteStop from "./RouteStop";
 import {inject} from "../../helpers/inject";
+import {SidePanelTabs} from "../../constants";
 
 const StopsListWrapper = styled.div`
   padding: 0.5rem 0;
@@ -22,6 +23,7 @@ const RouteStops = decorate(({routeStops, color, Filters, UI}) => {
     (stopId) => {
       if (stopId) {
         Filters.setStop(stopId);
+        UI.setSidePanelTab(SidePanelTabs.Timetables);
       }
     },
     [Filters]

--- a/src/components/sidepanel/SidePanel.js
+++ b/src/components/sidepanel/SidePanel.js
@@ -143,18 +143,20 @@ const SidePanel = decorate((props) => {
   // if it appears and nothing else is selected then it will be.
   let suggestedTab = "";
 
+  const routeId = createRouteId(route, true);
+
+  // The tabs will be auto-selected in this order, from top to bottom.
   if (areaSearchActive) suggestedTab = "area-journeys";
-  if (hasRoute) suggestedTab = "journeys";
-  if (user && vehicle) suggestedTab = "vehicle-journeys";
-  if (selectedJourney) suggestedTab = "journeys";
-  if (stateStop || stateTerminal) suggestedTab = "timetables";
+  if (user && vehicle) suggestedTab = `vehicle-journeys-${vehicle}`;
+  if (hasRoute) suggestedTab = `journeys-${routeId}`;
+  if (selectedJourney) suggestedTab = `journeys-${routeId}`;
+  if (stateStop || stateTerminal)
+    suggestedTab = `timetables-${stateStop || stateTerminal}`;
 
   const allTabsHidden =
     !hasRoute && !areaSearchActive && !vehicle && !stateStop && !stateTerminal;
 
   const detailsCanOpen = getJourneyId(selectedJourney) || route;
-
-  const routeId = createRouteId(route, true);
 
   return (
     <SidePanelContainer data-testid="sidepanel" visible={sidePanelVisible}>

--- a/src/components/sidepanel/SidepanelList.js
+++ b/src/components/sidepanel/SidepanelList.js
@@ -92,17 +92,14 @@ const SidepanelList = decorate(
       }
     }, [listHeight.current, scrollElementRef.current, scrollPositionRef.current]);
 
-    const prevFocusKey = useRef("");
-
     useEffect(() => {
       if (!loading) {
         // Update the scroll offset 100 ms after any update.
         // There must be a timer here otherwise the list may not be rendered
         // before the scroll offset is read.
         updateScrollOffsetTimer.current = setTimeout(() => {
-          updateScrollOffset(focusKey !== prevFocusKey.current);
-          prevFocusKey.current = focusKey;
-        }, 300);
+          updateScrollOffset();
+        }, 100);
       }
 
       return () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,3 +7,13 @@ export const TIME_SLIDER_MIN = 0; // 00:00:00
 export const TIME_SLIDER_DEFAULT_MIN = 16200; // 04:30
 export const STOP_EVENTS = ["DEP", "PDE", "PAS", "ARR", "ARS", "DUE", "WAIT"];
 export const ENV_NAME = process.env.REACT_APP_ENV_NAME || "";
+
+// Faux-enum for validating sidepanel tab changes
+export const SidePanelTabs = {
+  AreaJourneys: "area-journeys",
+  Journeys: "journeys",
+  WeekJourneys: "week-journeys",
+  VehicleJourneys: "vehicle-journeys",
+  Timetables: "timetables",
+  Alerts: "alerts",
+};

--- a/src/hooks/useDataDelay.js
+++ b/src/hooks/useDataDelay.js
@@ -20,11 +20,6 @@ export const useDataDelay = (journey) => {
       const recordedAt = parseISO(event.recordedAt);
 
       const delay = differenceInMilliseconds(receivedAt, recordedAt);
-
-      if (delay < 0) {
-        console.log(delay);
-      }
-
       delays.push(delay);
     }
 

--- a/src/stores/UIStore.js
+++ b/src/stores/UIStore.js
@@ -48,6 +48,7 @@ export default (state) => {
   extendObservable(
     state,
     {
+      sidePanelTab: getUrlValue("tab", ""),
       sidePanelVisible: getUrlValue("sidePanelVisible", true),
       journeyDetailsOpen: getUrlValue("journeysDetailsOpen", true),
       journeyGraphOpen: getUrlValue("journeyGraphOpen", false),

--- a/src/stores/uiActions.js
+++ b/src/stores/uiActions.js
@@ -10,6 +10,7 @@ import {latLng, LatLng, LatLngBounds} from "leaflet";
 import {intval} from "../helpers/isWithinRange";
 import {validBounds} from "../helpers/validBounds";
 import uniq from "lodash/uniq";
+import {SidePanelTabs} from "../constants";
 
 export default (state) => {
   const setMapZoom = action((value) => {
@@ -66,6 +67,16 @@ export default (state) => {
 
   const toggleShareModal = action((setTo = !state.shareModalOpen) => {
     state.shareModalOpen = setTo;
+  });
+
+  const setSidePanelTab = action((nextTab) => {
+    // Validate that this is actually a tab
+    if (Object.values(SidePanelTabs).includes(nextTab)) {
+      state.sidePanelTab = nextTab;
+      setUrlValue("tab", nextTab);
+    } else {
+      console.warn(`Non-existent tab ${nextTab} selected! You need to fix this.`);
+    }
   });
 
   const toggleSidePanel = action((setTo = !state.sidePanelVisible) => {
@@ -222,6 +233,7 @@ export default (state) => {
 
   return {
     toggleSidePanel,
+    setSidePanelTab,
     toggleJourneyDetails,
     toggleJourneyGraph,
     toggleLoginModal,


### PR DESCRIPTION
More logical auto-selection of tabs. The previous implementation was overly complicated and flaky and caused tests to fail. Now tabs are only auto-selected when the selected values are changed in the filterbar, rather than trying to heuristically work out which tab should be selected.