### PR TITLE
Skip live mode test

### DIFF
--- a/cypress/integration/time.spec.js
+++ b/cypress/integration/time.spec.js
@@ -56,7 +56,7 @@ describe("Time smoke tests", () => {
       });
   });
 
-  it("Can use live mode", () => {
+  it.skip("Can use live mode", () => {
     cy.getTestElement("route-input").type("2550/1");
     cy.getTestElement("route-option-2550-1").click({force: true});
 


### PR DESCRIPTION
Live mode is not an essential function and the E2E test is flaky, often making the whole testsuite fail even though the live mode works. Disable for now, circle back later if necessary.